### PR TITLE
Update v1.3.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# CS0618: Type or member is obsolete
+dotnet_diagnostic.CS0618.severity = silent

--- a/CHackLoader.cs
+++ b/CHackLoader.cs
@@ -22,10 +22,10 @@ namespace UmbraRoR
                 var component = (MonoBehaviour)gameObject.AddComponent(type);
                 component.enabled = false;
             }
-            gameObject.GetComponent<Main>().enabled = true;
-            gameObject.SetActive(true);
             Utility.LoadAssembly();
             Updates.CheckForUpdate();
+            gameObject.GetComponent<Main>().enabled = true;
+            gameObject.SetActive(true);
         }
 
         public static void Unload()

--- a/CHackLoader.cs
+++ b/CHackLoader.cs
@@ -6,17 +6,6 @@ namespace UmbraRoR
 {
     public class Loader
     {
-        //static GameObject gameObject;
-
-        /*public static void Load()
-        {
-            gameObject = new GameObject();
-            gameObject.AddComponent<Main>();
-            Object.DontDestroyOnLoad(gameObject);
-            Utility.LoadAssembly();
-            Updates.CheckForUpdate();
-        }*/
-
         public static GameObject gameObject;
 
         public static void Load()

--- a/CHackLoader.cs
+++ b/CHackLoader.cs
@@ -1,16 +1,40 @@
-﻿using UnityEngine;
+﻿using System.Linq;
+using System.Reflection;
+using UnityEngine;
 
 namespace UmbraRoR
 {
     public class Loader
     {
-        static GameObject gameObject;
+        //static GameObject gameObject;
 
-        public static void Load()
+        /*public static void Load()
         {
             gameObject = new GameObject();
             gameObject.AddComponent<Main>();
             Object.DontDestroyOnLoad(gameObject);
+            Utility.LoadAssembly();
+            Updates.CheckForUpdate();
+        }*/
+
+        public static GameObject gameObject;
+
+        public static void Load()
+        {
+            //RoR2.RoR2Application.isModded = true;
+            while (gameObject = GameObject.Find("Umbra Menu"))
+                GameObject.Destroy(gameObject);
+            gameObject = new GameObject("Umbra Menu");
+            Object.DontDestroyOnLoad(gameObject);
+            gameObject.SetActive(false);
+            var types = Assembly.GetExecutingAssembly().GetTypes().ToList().Where(t => t.BaseType == typeof(MonoBehaviour) && !t.IsNested);
+            foreach (var type in types)
+            {
+                var component = (MonoBehaviour)gameObject.AddComponent(type);
+                component.enabled = false;
+            }
+            gameObject.GetComponent<Main>().enabled = true;
+            gameObject.SetActive(true);
             Utility.LoadAssembly();
             Updates.CheckForUpdate();
         }

--- a/Chests.cs
+++ b/Chests.cs
@@ -13,8 +13,11 @@ namespace UmbraRoR
     {
         public static List<PurchaseInteraction> purchaseInteractions = new List<PurchaseInteraction>();//FindObjectsOfType<PurchaseInteraction>().ToList();
         public static List<ChestBehavior> chests = new List<ChestBehavior>();//ConvertPurchaseInteractsToChests();
+        public static float tier1Chance = 0.8f;
+        public static float tier2Chance = 0.2f;
+        public static float tier3Chance = 0.01f;
 
-        public static void Enabled()
+        public static void Enable()
         {
             if (Main.onChestsEnable)
             {
@@ -36,6 +39,61 @@ namespace UmbraRoR
                 }
             }
             return chests;
+        }
+
+        public static ChestBehavior FindClosestChest()
+        {
+            Dictionary<float, ChestBehavior> chestsWithDistance = new Dictionary<float, ChestBehavior>();
+            foreach (var chest in chests)
+            {
+                float distanceToChest = Vector3.Distance(Camera.main.transform.position, chest.transform.position);
+                chestsWithDistance.Add(distanceToChest, chest);
+            }
+            var keys = chestsWithDistance.Keys.ToList();
+            keys.Sort();
+            float leastDistance = keys[0];
+            chestsWithDistance.TryGetValue(leastDistance, out ChestBehavior closestChest);
+            return closestChest;
+        }
+
+        public static void RenderClosestChest()
+        {
+            var chest = FindClosestChest();
+            Vector3 chestPosition = Camera.main.WorldToScreenPoint(chest.transform.position);
+            var chestBoundingVector = new Vector3(chestPosition.x, chestPosition.y, chestPosition.z);
+            if (chestBoundingVector.z > 0.01)
+            {
+                float distanceToChest = Vector3.Distance(Camera.main.transform.position, FindClosestChest().transform.position);
+                float width = 100f * (distanceToChest / 100);
+                if (width > 125)
+                {
+                    width = 125;
+                }
+                float height = 100f * (distanceToChest / 100);
+                if (height > 125)
+                {
+                    height = 125;
+                }
+                GUI.Label(new Rect(chestBoundingVector.x - 50f, (float)Screen.height - chestBoundingVector.y + 50f, 100f, 50f), "Selected Chest", Main.selectedChestStyle);
+                ESPHelper.DrawBox(chestBoundingVector.x - width / 2, (float)Screen.height - chestBoundingVector.y - height / 2, width, height, new Color32(0, 255, 0, 255));
+            }
+        }
+
+        public static void SetChestItem(ItemIndex itemIndex)
+        {
+            var chest = FindClosestChest();
+            chest.SetField<PickupIndex>("dropPickup", PickupCatalog.FindPickupIndex(itemIndex));
+        }
+
+        public static void SetChestChance()
+        {
+            foreach (var chest in chests)
+            {
+                chest.tier1Chance = tier1Chance;
+                chest.tier2Chance = tier2Chance;
+                chest.tier3Chance = tier3Chance;
+                chest.RollItem();
+            }
         }
     }
 }

--- a/Chests.cs
+++ b/Chests.cs
@@ -1,0 +1,41 @@
+﻿using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace UmbraRoR
+{
+    class Chests : MonoBehaviour
+    {
+        public static List<PurchaseInteraction> purchaseInteractions = new List<PurchaseInteraction>();//FindObjectsOfType<PurchaseInteraction>().ToList();
+        public static List<ChestBehavior> chests = new List<ChestBehavior>();//ConvertPurchaseInteractsToChests();
+
+        public static void Enabled()
+        {
+            if (Main.onChestsEnable)
+            {
+                purchaseInteractions = FindObjectsOfType<PurchaseInteraction>().ToList();
+                chests = ConvertPurchaseInteractsToChests();
+                Main.onChestsEnable = false;
+            }
+        }
+
+        public static List<ChestBehavior> ConvertPurchaseInteractsToChests()
+        {
+            List<ChestBehavior> chests = new List<ChestBehavior>();
+            foreach (PurchaseInteraction purchaseInteraction in purchaseInteractions)
+            {
+                var chest = purchaseInteraction?.gameObject.GetComponent<ChestBehavior>();
+                if (chest)
+                {
+                    chests.Add(chest);
+                }
+            }
+            return chests;
+        }
+    }
+}

--- a/DrawMenu.cs
+++ b/DrawMenu.cs
@@ -452,7 +452,7 @@ namespace UmbraRoR
         public static void DrawChestItemMenu(float x, float y, float widthSize, int mulY, GUIStyle BGstyle, GUIStyle buttonStyle, GUIStyle LabelStyle)
         {
             GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * 15), "", BGstyle);
-            GUI.Label(new Rect(x + 5f, y + 5f, widthSize + 10, 85f), "I T E M S   L I S T", LabelStyle);
+            GUI.Label(new Rect(x + 5f, y + 5f, widthSize + 10, 85f), "C H A N G E   C H E S T   L I S T", LabelStyle);
 
             chestItemChangerScrollPosition = GUI.BeginScrollView(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * 15), chestItemChangerScrollPosition, new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * mulY), false, true);
             int buttonPlacement = 1;

--- a/DrawMenu.cs
+++ b/DrawMenu.cs
@@ -363,7 +363,7 @@ namespace UmbraRoR
             int heightMul = 15;
             if (Main.lowResolutionMonitor)
             {
-                heightMul = 7;
+                heightMul = 10;
             }
             GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * heightMul), "", BGstyle);
             GUI.Label(new Rect(x + 5f, y + 5f, widthSize + 5, 85f), "C H A R A C T E R   M E N U", LabelStyle);
@@ -378,7 +378,7 @@ namespace UmbraRoR
             int heightMul = 15;
             if (Main.lowResolutionMonitor)
             {
-                heightMul = 7;
+                heightMul = 10;
             }
             GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * heightMul), "", BGstyle);
             GUI.Label(new Rect(x + 5f, y + 5f, widthSize + 10, 85f), "B U F F S   L I S T", LabelStyle);
@@ -448,7 +448,7 @@ namespace UmbraRoR
             int heightMul = 15;
             if (Main.lowResolutionMonitor)
             {
-                heightMul = 7;
+                heightMul = 10;
             }
             GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * heightMul), "", BGstyle);
             GUI.Label(new Rect(x + 5f, y + 5f, widthSize + 10, 85f), "I T E M S   L I S T", LabelStyle);
@@ -457,9 +457,19 @@ namespace UmbraRoR
             int buttonPlacement = 1;
             foreach (var itemIndex in Main.items)
             {
-                string itemName = Util.GenerateColoredString(Language.GetString(ItemCatalog.GetItemDef(itemIndex).nameToken), ColorCatalog.GetColor(ItemCatalog.GetItemDef(itemIndex).colorIndex));
-                DrawButton(buttonPlacement, "itemSpawner", itemName, buttonStyle);
-                buttonPlacement++;
+                Color32 itemColor = ColorCatalog.GetColor(ItemCatalog.GetItemDef(itemIndex).colorIndex);
+                if (itemColor.r <= 105 && itemColor.g <= 105 && itemColor.b <= 105)
+                {
+                    string itemName = Util.GenerateColoredString(Language.GetString(ItemCatalog.GetItemDef(itemIndex).nameToken), new Color32(255, 255, 255, 255));
+                    DrawButton(buttonPlacement, "itemSpawner", itemName, buttonStyle);
+                    buttonPlacement++;
+                }
+                else
+                {
+                    string itemName = Util.GenerateColoredString(Language.GetString(ItemCatalog.GetItemDef(itemIndex).nameToken), itemColor);
+                    DrawButton(buttonPlacement, "itemSpawner", itemName, buttonStyle);
+                    buttonPlacement++;
+                }
             }
             GUI.EndScrollView();
         }
@@ -469,7 +479,7 @@ namespace UmbraRoR
             int heightMul = 15;
             if (Main.lowResolutionMonitor)
             {
-                heightMul = 7;
+                heightMul = 10;
             }
             GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * heightMul), "", BGstyle);
             GUI.Label(new Rect(x + 5f, y + 5f, widthSize + 10, 85f), "C H A N G E   C H E S T   L I S T", LabelStyle);
@@ -482,9 +492,19 @@ namespace UmbraRoR
                 {
                     if (equipmentIndex != EquipmentIndex.None)
                     {
-                        string equipmentName = Util.GenerateColoredString(Language.GetString(EquipmentCatalog.GetEquipmentDef(equipmentIndex).nameToken), ColorCatalog.GetColor(EquipmentCatalog.GetEquipmentDef(equipmentIndex).colorIndex));
-                        DrawButton(buttonPlacement, "chestItemChanger", equipmentName, buttonStyle);
-                        buttonPlacement++;
+                        Color32 equipColor = ColorCatalog.GetColor(EquipmentCatalog.GetEquipmentDef(equipmentIndex).colorIndex);
+                        if (equipColor.r <= 105 && equipColor.g <= 105 && equipColor.b <= 105)
+                        {
+                            string equipmentName = Util.GenerateColoredString(Language.GetString(EquipmentCatalog.GetEquipmentDef(equipmentIndex).nameToken), new Color32(255, 255, 255, 255));
+                            DrawButton(buttonPlacement, "chestItemChanger", equipmentName, buttonStyle);
+                            buttonPlacement++;
+                        }
+                        else
+                        {
+                            string equipmentName = Util.GenerateColoredString(Language.GetString(EquipmentCatalog.GetEquipmentDef(equipmentIndex).nameToken), ColorCatalog.GetColor(EquipmentCatalog.GetEquipmentDef(equipmentIndex).colorIndex));
+                            DrawButton(buttonPlacement, "chestItemChanger", equipmentName, buttonStyle);
+                            buttonPlacement++;
+                        }
                     }
                 }
             }
@@ -492,9 +512,19 @@ namespace UmbraRoR
             {
                 foreach (var itemIndex in Main.items)
                 {
-                    string itemName = itemIndex.ToString();
-                    DrawButton(buttonPlacement, "chestItemChanger", itemName, buttonStyle);
-                    buttonPlacement++;
+                    Color32 itemColor = ColorCatalog.GetColor(ItemCatalog.GetItemDef(itemIndex).colorIndex);
+                    if (itemColor.r <= 105 && itemColor.g <= 105 && itemColor.b <= 105)
+                    {
+                        string itemName = Util.GenerateColoredString(Language.GetString(ItemCatalog.GetItemDef(itemIndex).nameToken), new Color32(255, 255, 255, 255));
+                        DrawButton(buttonPlacement, "chestItemChanger", itemName, buttonStyle);
+                        buttonPlacement++;
+                    }
+                    else
+                    {
+                        string itemName = Util.GenerateColoredString(Language.GetString(ItemCatalog.GetItemDef(itemIndex).nameToken), itemColor);
+                        DrawButton(buttonPlacement, "chestItemChanger", itemName, buttonStyle);
+                        buttonPlacement++;
+                    }
                 }
             }
             GUI.EndScrollView();
@@ -516,7 +546,7 @@ namespace UmbraRoR
             int heightMul = 15;
             if (Main.lowResolutionMonitor)
             {
-                heightMul = 7;
+                heightMul = 10;
             }
             GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * heightMul), "", BGstyle);
             GUI.Label(new Rect(x + 5f, y + 5f, widthSize + 10, 85f), "E Q U I P M E N T   L I S T", LabelStyle);
@@ -527,9 +557,19 @@ namespace UmbraRoR
             {
                 if (equipmentIndex != EquipmentIndex.None)
                 {
-                    string equipmentName = Util.GenerateColoredString(Language.GetString(EquipmentCatalog.GetEquipmentDef(equipmentIndex).nameToken), ColorCatalog.GetColor(EquipmentCatalog.GetEquipmentDef(equipmentIndex).colorIndex));
-                    DrawButton(buttonPlacement, "equipmentSpawner", equipmentName, buttonStyle);
-                    buttonPlacement++;
+                    Color32 equipColor = ColorCatalog.GetColor(EquipmentCatalog.GetEquipmentDef(equipmentIndex).colorIndex);
+                    if (equipColor.r <= 105 && equipColor.g <= 105 && equipColor.b <= 105)
+                    {
+                        string equipmentName = Util.GenerateColoredString(Language.GetString(EquipmentCatalog.GetEquipmentDef(equipmentIndex).nameToken), new Color32(255, 255, 255, 255));
+                        DrawButton(buttonPlacement, "equipmentSpawner", equipmentName, buttonStyle);
+                        buttonPlacement++;
+                    }
+                    else
+                    {
+                        string equipmentName = Util.GenerateColoredString(Language.GetString(EquipmentCatalog.GetEquipmentDef(equipmentIndex).nameToken), equipColor);
+                        DrawButton(buttonPlacement, "equipmentSpawner", equipmentName, buttonStyle);
+                        buttonPlacement++;
+                    }
                 }
                 else
                 {

--- a/DrawMenu.cs
+++ b/DrawMenu.cs
@@ -251,6 +251,15 @@ namespace UmbraRoR
 
             DrawButton(8, "itemmanager", "S T A C K   I N V E N T O R Y", buttonStyle);
             DrawButton(9, "itemmanager", "C L E A R   I N V E N T O R Y", buttonStyle);
+
+            if (Main._isChangeCharacterMenuOpen)
+            {
+                DrawButton(10, "itemmanager", "C H A N G E   C H E S T   I T E M : O N", buttonStyle);
+            }
+            else
+            {
+                DrawButton(10, "itemmanager", "C H A N G E   C H E S T   I T E M : O F F", buttonStyle);
+            }
         }
 
         public static void DrawSpawnMenu(float x, float y, float widthSize, int mulY, GUIStyle BGstyle, GUIStyle buttonStyle, GUIStyle OnStyle, GUIStyle OffStyle, GUIStyle LabelStyle)
@@ -447,11 +456,23 @@ namespace UmbraRoR
 
             chestItemChangerScrollPosition = GUI.BeginScrollView(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * 15), chestItemChangerScrollPosition, new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * mulY), false, true);
             int buttonPlacement = 1;
-            foreach (var itemIndex in Main.items)
+            if (Chests.IsClosestChestEquip())
             {
-                string itemName = itemIndex.ToString();
-                DrawButton(buttonPlacement, "chestItemChanger", itemName, buttonStyle);
-                buttonPlacement++;
+                foreach (var equipmentIndex in Main.equipment)
+                {
+                    string equipmentName = equipmentIndex.ToString();
+                    DrawButton(buttonPlacement, "chestItemChanger", equipmentName, buttonStyle);
+                    buttonPlacement++;
+                }
+            }
+            else
+            {
+                foreach (var itemIndex in Main.items)
+                {
+                    string itemName = itemIndex.ToString();
+                    DrawButton(buttonPlacement, "chestItemChanger", itemName, buttonStyle);
+                    buttonPlacement++;
+                }
             }
             GUI.EndScrollView();
         }
@@ -461,10 +482,10 @@ namespace UmbraRoR
             GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * 15), "", BGstyle);
             GUI.Label(new Rect(x + 5f, y + 5f, widthSize + 10, 85f), "C H E S T   M E N U", LabelStyle);
 
-            DrawButton(1, "chestManagement", $"T I E R   1 : {Chests.FindClosestChest().tier1Chance / 100}%", buttonStyle, isMultButton: true);
-            DrawButton(2, "chestManagement", $"T I E R   2 : {Chests.FindClosestChest().tier2Chance / 100}%", buttonStyle, isMultButton: true);
-            DrawButton(3, "chestManagement", $"T I E R   3 : {Chests.FindClosestChest().tier3Chance / 100}%", buttonStyle, isMultButton: true);
-            DrawButton(4, "chestManagement", "C L O S E S T   C H E S T   I T E M", buttonStyle);
+            //DrawButton(1, "chestManagement", $"T I E R   1 : {Chests.FindClosestChest().tier1Chance / 100}%", buttonStyle, isMultButton: true);
+            //DrawButton(2, "chestManagement", $"T I E R   2 : {Chests.FindClosestChest().tier2Chance / 100}%", buttonStyle, isMultButton: true);
+            //DrawButton(3, "chestManagement", $"T I E R   3 : {Chests.FindClosestChest().tier3Chance / 100}%", buttonStyle, isMultButton: true);
+            //DrawButton(4, "chestManagement", "C L O S E S T   C H E S T   I T E M", buttonStyle);
         }
 
         public static void DrawEquipmentMenu(float x, float y, float widthSize, int mulY, GUIStyle BGstyle, GUIStyle buttonStyle, GUIStyle LabelStyle, GUIStyle offStyle)
@@ -666,6 +687,22 @@ namespace UmbraRoR
                         else
                         {
                             rect = new Rect(Main.equipmentSpawnerRect.x + 5, Main.equipmentSpawnerRect.y + 5 + 45 * position, Main.widthSize, 40);
+                        }
+                        break;
+                    }
+
+                case "chestItemChanger":
+                    {
+                        menuIndex = 3.3f;
+                        menuBg = Main.chestItemChangerRect;
+                        Main.chestItemChangerRectMulY = position;
+                        if (isMultButton)
+                        {
+                            rect = new Rect(Main.chestItemChangerRect.x + 5, Main.chestItemChangerRect.y + 5 + 45 * position, Main.widthSize - 90, 40);
+                        }
+                        else
+                        {
+                            rect = new Rect(Main.chestItemChangerRect.x + 5, Main.chestItemChangerRect.y + 5 + 45 * position, Main.widthSize, 40);
                         }
                         break;
                     }

--- a/DrawMenu.cs
+++ b/DrawMenu.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace UmbraRoR
 {
-    internal class DrawMenu
+    internal class DrawMenu : MonoBehaviour
     {
         public static Vector2 itemSpawnerScrollPosition = Vector2.zero;
         public static Vector2 equipmentSpawnerScrollPosition = Vector2.zero;

--- a/DrawMenu.cs
+++ b/DrawMenu.cs
@@ -442,7 +442,7 @@ namespace UmbraRoR
             int buttonPlacement = 1;
             foreach (var itemIndex in Main.items)
             {
-                string itemName = itemIndex.ToString();
+                string itemName = Util.GenerateColoredString(Language.GetString(ItemCatalog.GetItemDef(itemIndex).nameToken), ColorCatalog.GetColor(ItemCatalog.GetItemDef(itemIndex).colorIndex));
                 DrawButton(buttonPlacement, "itemSpawner", itemName, buttonStyle);
                 buttonPlacement++;
             }
@@ -460,9 +460,12 @@ namespace UmbraRoR
             {
                 foreach (var equipmentIndex in Main.equipment)
                 {
-                    string equipmentName = equipmentIndex.ToString();
-                    DrawButton(buttonPlacement, "chestItemChanger", equipmentName, buttonStyle);
-                    buttonPlacement++;
+                    if (equipmentIndex != EquipmentIndex.None)
+                    {
+                        string equipmentName = Util.GenerateColoredString(Language.GetString(EquipmentCatalog.GetEquipmentDef(equipmentIndex).nameToken), ColorCatalog.GetColor(EquipmentCatalog.GetEquipmentDef(equipmentIndex).colorIndex));
+                        DrawButton(buttonPlacement, "chestItemChanger", equipmentName, buttonStyle);
+                        buttonPlacement++;
+                    }
                 }
             }
             else
@@ -497,9 +500,18 @@ namespace UmbraRoR
             int buttonPlacement = 1;
             foreach (var equipmentIndex in Main.equipment)
             {
-                string equipmentName = equipmentIndex.ToString();
-                DrawButton(buttonPlacement, "equipmentSpawner", equipmentName, buttonStyle);
-                buttonPlacement++;
+                if (equipmentIndex != EquipmentIndex.None)
+                {
+                    string equipmentName = Util.GenerateColoredString(Language.GetString(EquipmentCatalog.GetEquipmentDef(equipmentIndex).nameToken), ColorCatalog.GetColor(EquipmentCatalog.GetEquipmentDef(equipmentIndex).colorIndex));
+                    DrawButton(buttonPlacement, "equipmentSpawner", equipmentName, buttonStyle);
+                    buttonPlacement++;
+                }
+                else
+                {
+                    string equipmentName = "Remove Equipment";
+                    DrawButton(buttonPlacement, "equipmentSpawner", equipmentName, buttonStyle);
+                    buttonPlacement++;
+                }
             }
             GUI.EndScrollView();
         }

--- a/DrawMenu.cs
+++ b/DrawMenu.cs
@@ -433,13 +433,16 @@ namespace UmbraRoR
             {
                 DrawButton(5, "statsmod", $"M O V E   S P E E D ( O F F ) : {PlayerMod.movespeed}", OffStyle, true);
             }
+
+            DrawButton(6, "statsmod", $"M U L T I P L I E R : {PlayerMod.multiplyer}", buttonStyle, true);
+
             if (Main._isStatMenuOpen)
             {
-                DrawButton(6, "statsmod", "S H O W   S T A T S : O N", OnStyle);
+                DrawButton(7, "statsmod", "S H O W   S T A T S : O N", OnStyle);
             }
             else
             {
-                DrawButton(6, "statsmod", "S H O W   S T A T S : O F F", OffStyle);
+                DrawButton(7, "statsmod", "S H O W   S T A T S : O F F", OffStyle);
             }
         }
 

--- a/DrawMenu.cs
+++ b/DrawMenu.cs
@@ -6,6 +6,7 @@ namespace UmbraRoR
 {
     internal class DrawMenu : MonoBehaviour
     {
+        public static Vector2 chestItemChangerScrollPosition = Vector2.zero;
         public static Vector2 itemSpawnerScrollPosition = Vector2.zero;
         public static Vector2 equipmentSpawnerScrollPosition = Vector2.zero;
         public static Vector2 buffMenuScrollPosition = Vector2.zero;
@@ -437,6 +438,33 @@ namespace UmbraRoR
                 buttonPlacement++;
             }
             GUI.EndScrollView();
+        }
+
+        public static void DrawChestItemMenu(float x, float y, float widthSize, int mulY, GUIStyle BGstyle, GUIStyle buttonStyle, GUIStyle LabelStyle)
+        {
+            GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * 15), "", BGstyle);
+            GUI.Label(new Rect(x + 5f, y + 5f, widthSize + 10, 85f), "I T E M S   L I S T", LabelStyle);
+
+            chestItemChangerScrollPosition = GUI.BeginScrollView(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * 15), chestItemChangerScrollPosition, new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * mulY), false, true);
+            int buttonPlacement = 1;
+            foreach (var itemIndex in Main.items)
+            {
+                string itemName = itemIndex.ToString();
+                DrawButton(buttonPlacement, "chestItemChanger", itemName, buttonStyle);
+                buttonPlacement++;
+            }
+            GUI.EndScrollView();
+        }
+
+        public static void DrawChestMenu(float x, float y, float widthSize, int mulY, GUIStyle BGstyle, GUIStyle buttonStyle, GUIStyle LabelStyle)
+        {
+            GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * 15), "", BGstyle);
+            GUI.Label(new Rect(x + 5f, y + 5f, widthSize + 10, 85f), "C H E S T   M E N U", LabelStyle);
+
+            DrawButton(1, "chestManagement", $"T I E R   1 : {Chests.FindClosestChest().tier1Chance / 100}%", buttonStyle, isMultButton: true);
+            DrawButton(2, "chestManagement", $"T I E R   2 : {Chests.FindClosestChest().tier2Chance / 100}%", buttonStyle, isMultButton: true);
+            DrawButton(3, "chestManagement", $"T I E R   3 : {Chests.FindClosestChest().tier3Chance / 100}%", buttonStyle, isMultButton: true);
+            DrawButton(4, "chestManagement", "C L O S E S T   C H E S T   I T E M", buttonStyle);
         }
 
         public static void DrawEquipmentMenu(float x, float y, float widthSize, int mulY, GUIStyle BGstyle, GUIStyle buttonStyle, GUIStyle LabelStyle, GUIStyle offStyle)

--- a/DrawMenu.cs
+++ b/DrawMenu.cs
@@ -360,20 +360,30 @@ namespace UmbraRoR
 
         public static void CharacterWindowMethod(float x, float y, float widthSize, int mulY, GUIStyle BGstyle, GUIStyle buttonStyle, GUIStyle LabelStyle)
         {
-            GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * 15), "", BGstyle);
+            int heightMul = 15;
+            if (Main.lowResolutionMonitor)
+            {
+                heightMul = 7;
+            }
+            GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * heightMul), "", BGstyle);
             GUI.Label(new Rect(x + 5f, y + 5f, widthSize + 5, 85f), "C H A R A C T E R   M E N U", LabelStyle);
 
-            characterScrollPosition = GUI.BeginScrollView(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * 15), characterScrollPosition, new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * mulY), false, true);
+            characterScrollPosition = GUI.BeginScrollView(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * heightMul), characterScrollPosition, new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * mulY), false, true);
             PlayerMod.ChangeCharacter(buttonStyle, "character");
             GUI.EndScrollView();
         }
 
         public static void DrawBuffMenu(float x, float y, float widthSize, int mulY, GUIStyle BGstyle, GUIStyle buttonStyle, GUIStyle LabelStyle, GUIStyle offStyle)
         {
-            GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * 15), "", BGstyle);
+            int heightMul = 15;
+            if (Main.lowResolutionMonitor)
+            {
+                heightMul = 7;
+            }
+            GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * heightMul), "", BGstyle);
             GUI.Label(new Rect(x + 5f, y + 5f, widthSize + 10, 85f), "B U F F S   L I S T", LabelStyle);
 
-            buffMenuScrollPosition = GUI.BeginScrollView(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * 15), buffMenuScrollPosition, new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * mulY), false, true);
+            buffMenuScrollPosition = GUI.BeginScrollView(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * heightMul), buffMenuScrollPosition, new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * mulY), false, true);
             PlayerMod.GiveBuff(buttonStyle, "giveBuff");
             GUI.EndScrollView();
         }
@@ -435,10 +445,15 @@ namespace UmbraRoR
 
         public static void DrawItemMenu(float x, float y, float widthSize, int mulY, GUIStyle BGstyle, GUIStyle buttonStyle, GUIStyle LabelStyle)
         {
-            GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * 15), "", BGstyle);
+            int heightMul = 15;
+            if (Main.lowResolutionMonitor)
+            {
+                heightMul = 7;
+            }
+            GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * heightMul), "", BGstyle);
             GUI.Label(new Rect(x + 5f, y + 5f, widthSize + 10, 85f), "I T E M S   L I S T", LabelStyle);
 
-            itemSpawnerScrollPosition = GUI.BeginScrollView(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * 15), itemSpawnerScrollPosition, new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * mulY), false, true);
+            itemSpawnerScrollPosition = GUI.BeginScrollView(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * heightMul), itemSpawnerScrollPosition, new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * mulY), false, true);
             int buttonPlacement = 1;
             foreach (var itemIndex in Main.items)
             {
@@ -451,10 +466,15 @@ namespace UmbraRoR
 
         public static void DrawChestItemMenu(float x, float y, float widthSize, int mulY, GUIStyle BGstyle, GUIStyle buttonStyle, GUIStyle LabelStyle)
         {
-            GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * 15), "", BGstyle);
+            int heightMul = 15;
+            if (Main.lowResolutionMonitor)
+            {
+                heightMul = 7;
+            }
+            GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * heightMul), "", BGstyle);
             GUI.Label(new Rect(x + 5f, y + 5f, widthSize + 10, 85f), "C H A N G E   C H E S T   L I S T", LabelStyle);
 
-            chestItemChangerScrollPosition = GUI.BeginScrollView(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * 15), chestItemChangerScrollPosition, new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * mulY), false, true);
+            chestItemChangerScrollPosition = GUI.BeginScrollView(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * heightMul), chestItemChangerScrollPosition, new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * mulY), false, true);
             int buttonPlacement = 1;
             if (Chests.IsClosestChestEquip())
             {
@@ -493,10 +513,15 @@ namespace UmbraRoR
 
         public static void DrawEquipmentMenu(float x, float y, float widthSize, int mulY, GUIStyle BGstyle, GUIStyle buttonStyle, GUIStyle LabelStyle, GUIStyle offStyle)
         {
-            GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * 15), "", BGstyle);
+            int heightMul = 15;
+            if (Main.lowResolutionMonitor)
+            {
+                heightMul = 7;
+            }
+            GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * heightMul), "", BGstyle);
             GUI.Label(new Rect(x + 5f, y + 5f, widthSize + 10, 85f), "E Q U I P M E N T   L I S T", LabelStyle);
 
-            equipmentSpawnerScrollPosition = GUI.BeginScrollView(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * 15), equipmentSpawnerScrollPosition, new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * mulY), false, true);
+            equipmentSpawnerScrollPosition = GUI.BeginScrollView(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * heightMul), equipmentSpawnerScrollPosition, new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * mulY), false, true);
             int buttonPlacement = 1;
             foreach (var equipmentIndex in Main.equipment)
             {
@@ -518,10 +543,15 @@ namespace UmbraRoR
 
         public static void DrawSpawnMobMenu(float x, float y, float widthSize, int mulY, GUIStyle BGstyle, GUIStyle buttonStyle, GUIStyle LabelStyle)
         {
-            GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * 15), "", BGstyle);
+            int heightMul = 15;
+            if (Main.lowResolutionMonitor)
+            {
+                heightMul = 7;
+            }
+            GUI.Box(new Rect(x + 0f, y + 0f, widthSize + 20, 50f + 45 * heightMul), "", BGstyle);
             GUI.Label(new Rect(x + 5f, y + 5f, widthSize + 10, 85f), "S P A W N   L I S T", LabelStyle);
 
-            spawnScrollPosition = GUI.BeginScrollView(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * 15), spawnScrollPosition, new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * mulY), false, true);
+            spawnScrollPosition = GUI.BeginScrollView(new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * heightMul), spawnScrollPosition, new Rect(x + 0f, y + 0f, widthSize + 10, 50f + 45 * mulY), false, true);
             Spawn.SpawnMob(buttonStyle, "spawnMob");
             GUI.EndScrollView();
         }

--- a/ItemManager.cs
+++ b/ItemManager.cs
@@ -7,7 +7,7 @@ using UnityEngine.Networking;
 
 namespace UmbraRoR 
 {
-    public class ItemManager 
+    public class ItemManager : MonoBehaviour
     {
         public static int itemsToRoll = 5;
         public static bool isDropItemForAll = false;

--- a/Lobby.cs
+++ b/Lobby.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using RoR2;
+using UnityEngine;
 using Console = RoR2.Console;
 
 namespace UmbraRoR
 {
-    class Lobby
+    class Lobby : MonoBehaviour
     {
         // More posibilities here using console.
         // Not added to ui yet.

--- a/Main.cs
+++ b/Main.cs
@@ -631,7 +631,7 @@ namespace UmbraRoR
                     if (Input.GetKeyDown(KeyCode.RightArrow))
                     {
                         bool playerPlusMinusBtn = Navigation.menuIndex == 1 && Enumerable.Range(0, 3).Contains(Navigation.intraMenuIndex);
-                        bool statsPlusMinusBtn = Navigation.menuIndex == 1.3f && Enumerable.Range(0, 5).Contains(Navigation.intraMenuIndex);
+                        bool statsPlusMinusBtn = Navigation.menuIndex == 1.3f && Enumerable.Range(0, 6).Contains(Navigation.intraMenuIndex);
                         bool itemPlusMinusBtn = Navigation.menuIndex == 3 && Enumerable.Range(0, 2).Contains(Navigation.intraMenuIndex);
                         bool spawnPlusMinusBtn = Navigation.menuIndex == 4 && Enumerable.Range(0, 3).Contains(Navigation.intraMenuIndex);
                         if (playerPlusMinusBtn || itemPlusMinusBtn || statsPlusMinusBtn || spawnPlusMinusBtn)
@@ -653,7 +653,7 @@ namespace UmbraRoR
                     if (Input.GetKeyDown(KeyCode.LeftArrow))
                     {
                         bool playerPlusMinusBtn = Navigation.menuIndex == 1 && Enumerable.Range(0, 3).Contains(Navigation.intraMenuIndex);
-                        bool statsPlusMinusBtn = Navigation.menuIndex == 1.3f && Enumerable.Range(0, 5).Contains(Navigation.intraMenuIndex);
+                        bool statsPlusMinusBtn = Navigation.menuIndex == 1.3f && Enumerable.Range(0, 6).Contains(Navigation.intraMenuIndex);
                         bool itemPlusMinusBtn = Navigation.menuIndex == 3 && Enumerable.Range(0, 2).Contains(Navigation.intraMenuIndex);
                         bool spawnPlusMinusBtn = Navigation.menuIndex == 4 && Enumerable.Range(0, 3).Contains(Navigation.intraMenuIndex);
                         if (playerPlusMinusBtn || itemPlusMinusBtn || statsPlusMinusBtn || spawnPlusMinusBtn)

--- a/Main.cs
+++ b/Main.cs
@@ -715,13 +715,19 @@ namespace UmbraRoR
             if (Input.GetKeyDown(KeyCode.Z))
             {
                 _isPlayerMod = !_isPlayerMod;
-                Navigation.menuIndex = 1;
+                if (navigationToggle)
+                {
+                    Navigation.menuIndex = 1;
+                }
             }
 
             if (Input.GetKeyDown(KeyCode.I))
             {
                 _isItemSpawnMenuOpen = !_isItemSpawnMenuOpen;
-                Navigation.menuIndex = 3.1f;
+                if (navigationToggle)
+                {
+                    Navigation.menuIndex = 3.1f;
+                }
             }
 
             if (Input.GetKeyDown(KeyCode.C))
@@ -732,7 +738,10 @@ namespace UmbraRoR
             if (Input.GetKeyDown(KeyCode.B))
             {
                 _isTeleMenuOpen = !_isTeleMenuOpen;
-                Navigation.menuIndex = 5;
+                if (navigationToggle)
+                {
+                    Navigation.menuIndex = 5;
+                }
             }
         }
         #endregion Inputs

--- a/Main.cs
+++ b/Main.cs
@@ -59,6 +59,11 @@ namespace UmbraRoR
         public static CharacterMotor LocalMotor;
         #endregion
 
+        #region Enable Checks
+        public static bool onChestsEnable = true;
+        public static bool onChestsDisable = false;
+        #endregion
+
         #region Menu Checks
         public static bool _isMenuOpen = false;
         public static bool _ifDragged = false;

--- a/Main.cs
+++ b/Main.cs
@@ -650,6 +650,7 @@ namespace UmbraRoR
                 Navigation.menuIndex = 0;
                 Cursor.visible = false;
             }
+
             if (Input.GetKeyDown(KeyCode.Insert))
             {
                 unloadConfirm = false;
@@ -662,6 +663,29 @@ namespace UmbraRoR
                 _isMenuOpen = !_isMenuOpen;
                 GetCharacter();
                 SceneManager.sceneLoaded += OnSceneLoaded;
+            }
+
+            if (Input.GetKeyDown(KeyCode.Z))
+            {
+                _isPlayerMod = !_isPlayerMod;
+                Navigation.menuIndex = 1;
+            }
+
+            if (Input.GetKeyDown(KeyCode.I))
+            {
+                _isItemSpawnMenuOpen = !_isItemSpawnMenuOpen;
+                Navigation.menuIndex = 3.1f;
+            }
+
+            if (Input.GetKeyDown(KeyCode.C))
+            {
+                FlightToggle = !FlightToggle;
+            }
+
+            if (Input.GetKeyDown(KeyCode.B))
+            {
+                _isTeleMenuOpen = !_isTeleMenuOpen;
+                Navigation.menuIndex = 5;
             }
         }
         #endregion Inputs

--- a/Main.cs
+++ b/Main.cs
@@ -82,13 +82,14 @@ namespace UmbraRoR
         public static bool _isSpawnListMenuOpen = false;
         public static bool _isSpawnMenuOpen = false;
         public static bool _isChestItemListOpen = false;
+        public static bool lowResolutionMonitor = false;
         public static bool enableRespawnButton = false;
         #endregion
 
         #region Button Styles / Toggles
         public static GUIStyle MainBgStyle, StatBgSytle, TeleBgStyle, OnStyle, OffStyle, LabelStyle, TitleStyle, BtnStyle, ItemBtnStyle, CornerStyle, DisplayStyle, BgStyle, HighlightBtnStyle, ActiveModsStyle, renderTeleporterStyle, renderMobsStyle, renderInteractablesStyle, WatermarkStyle, StatsStyle, selectedChestStyle;
         public static GUIStyle BtnStyle1, BtnStyle2, BtnStyle3;
-        public static bool skillToggle, renderInteractables, renderMobs, damageToggle, critToggle, attackSpeedToggle, armorToggle, regenToggle, moveSpeedToggle, MouseToggle, FlightToggle, listItems, noEquipmentCooldown, listBuffs, aimBot, alwaysSprint, godToggle, unloadConfirm, jumpPackToggle, tier1Toggle, tier2Toggle, tier3Toggle=true;
+        public static bool skillToggle, renderInteractables, renderMobs, damageToggle, critToggle, attackSpeedToggle, armorToggle, regenToggle, moveSpeedToggle, MouseToggle, FlightToggle, listItems, noEquipmentCooldown, listBuffs, aimBot, alwaysSprint, godToggle, unloadConfirm, jumpPackToggle, tier1Toggle, tier2Toggle, tier3Toggle, scrolled;
         public static bool renderActiveMods = true;
         public static float delay = 0, widthSize = 350;
         public static bool navigationToggle = false;
@@ -298,7 +299,26 @@ namespace UmbraRoR
             }
             else
             {
-                return;
+                lowResolutionMonitor = true;
+                renderActiveMods = false;
+                mainRect = new Rect(10, 10, 20, 20); // start position
+                playerModRect = new Rect(374, 10, 20, 20); // start position
+                movementRect = new Rect(374, 10, 20, 20); // start position
+                itemManagerRect = new Rect(374, 10, 20, 20); // start positions
+                teleRect = new Rect(374, 10, 20, 20); // start position
+                ESPRect = new Rect(374, 10, 20, 20); // start position
+                lobbyRect = new Rect(374, 10, 20, 20); // start position
+                spawnRect = new Rect(374, 10, 20, 20); // start position
+
+                statRect = new Rect(374, 10, 20, 20); // start position
+
+                spawnListRect = new Rect(374, 10, 20, 20); // start position
+                itemSpawnerRect = new Rect(374, 10, 20, 20); // start position
+                chestItemChangerRect = new Rect(374, 10, 20, 20); // start position
+                equipmentSpawnerRect = new Rect(374, 10, 20, 20); // start positions
+                buffMenuRect = new Rect(374, 10, 20, 20); // start position
+                characterRect = new Rect(374, 10, 20, 20); // start position
+                editStatsRect = new Rect(374, 10, 20, 20); // start position
             }
 
             #endregion
@@ -550,10 +570,18 @@ namespace UmbraRoR
         #region FixedUpdate
         public void FixedUpdate()
         {
-            currentScene = SceneManager.GetActiveScene();
-            if (renderMobs)
+            try
             {
-                hurtBoxes = Utility.GetHurtBoxes();
+                LowResolutionRoutine();
+                currentScene = SceneManager.GetActiveScene();
+                if (renderMobs)
+                {
+                    hurtBoxes = Utility.GetHurtBoxes();
+                }
+            }
+            catch
+            {
+                throw;
             }
         }
         #endregion
@@ -641,6 +669,25 @@ namespace UmbraRoR
                     {
                         Navigation.GoBackAMenu();
                     }
+
+                    if (_isBuffMenuOpen || _isChangeCharacterMenuOpen || _isChestItemListOpen || _isEquipmentSpawnMenuOpen || _isItemSpawnMenuOpen || _isSpawnListMenuOpen)
+                    {
+                        if (!scrolled)
+                        {
+                            if (Input.GetAxis("Mouse ScrollWheel") != 0f) // Scrolled
+                            {
+                                scrolled = true;
+                            }
+                        }
+                        else
+                        {
+                            if (Input.GetKeyDown(KeyCode.DownArrow) || Input.GetKeyDown(KeyCode.UpArrow))
+                            {
+                                scrolled = false;
+                            }
+                        }
+
+                    }
                 }
             }
             else if (!_isMenuOpen)
@@ -696,6 +743,15 @@ namespace UmbraRoR
             if (!_CharacterCollected)
             {
                 GetCharacter();
+            }
+        }
+
+        private void LowResolutionRoutine()
+        {
+            if (lowResolutionMonitor)
+            {
+                Utility.MenusOpenKeys();
+                LowResolutionMonitor();
             }
         }
 
@@ -1107,7 +1163,7 @@ namespace UmbraRoR
 
         public static void SetItemSpawnerBG(int windowID)
         {
-            GUI.Box(new Rect(0f, 0f, widthSize + 10, 50f + 45 * MainMulY), "", CornerStyle);
+            GUI.Box(new Rect(0f, 0f, widthSize + 10, 50f + 45 * itemSpawnerMulY), "", CornerStyle);
             if (Event.current.type == EventType.MouseDrag)
             {
                 delay += Time.deltaTime;
@@ -1469,5 +1525,115 @@ namespace UmbraRoR
             }
         }
         #endregion
+
+        private void LowResolutionMonitor()
+        {
+            int i = 1;
+            var menusOpen = Utility.MenusOpenKeys();
+            if (menusOpen.Count > 2)
+            {
+                if (Navigation.lowResMenuIndex < Navigation.prevLowResMenuIndex)
+                {
+                    i = 2;
+                }
+
+                switch (menusOpen[i])
+                {
+                    case 0: // Main Menu 
+                        {
+                            break;
+                        }
+
+                    case 1: // Player Management Menu
+                        {
+                            _isPlayerMod = false;
+                            break;
+                        }
+
+                    case 1.1f: // Character Menu
+                        {
+                            _isChangeCharacterMenuOpen = false;
+                            break;
+                        }
+
+                    case 1.2f: // Buff Menu
+                        {
+                            _isBuffMenuOpen = false;
+                            break;
+                        }
+
+                    case 1.3f: // Stats Modification Menu
+                        {
+                            _isEditStatsOpen = false;
+                            break;
+                        }
+
+                    case 2: // Movement Menu
+                        {
+                            _isMovementOpen = false;
+                            break;
+                        }
+
+                    case 3: // Item Management Menu
+                        {
+                            _isItemManagerOpen = false;
+                            break;
+                        }
+
+                    case 3.1f: // Give Item Menu
+                        {
+                            _isItemSpawnMenuOpen = false;
+                            break;
+                        }
+
+                    case 3.2f: // Give Equipment Menu
+                        {
+                            _isEquipmentSpawnMenuOpen = false;
+                            break;
+                        }
+
+                    case 3.3f: // Change Chest Item List Menu
+                        {
+                            _isChestItemListOpen = false;
+                            break;
+                        }
+
+                    case 4: // Spawn Menu
+                        {
+                            _isSpawnMenuOpen = false;
+                            break;
+                        }
+
+                    case 4.1f: // Spawn List Menu
+                        {
+                            _isSpawnListMenuOpen = false;
+                            break;
+                        }
+
+                    case 5: // Teleporter Menu
+                        {
+                            _isTeleMenuOpen = false;
+                            break;
+                        }
+
+                    case 6: // Render Menu
+                        {
+                            _isESPMenuOpen = false;
+                            break;
+                        }
+
+                    case 7: // Lobby Management Menu
+                        {
+                            _isLobbyMenuOpen = false;
+                            break;
+                        }
+
+                    default:
+                        {
+                            break;
+                        }
+                }
+            }
+        }
     }
 }

--- a/Main.cs
+++ b/Main.cs
@@ -34,8 +34,9 @@ namespace UmbraRoR
         public static List<SpawnCard> spawnCards = Utility.GetSpawnCards();
 
         // These Are updated in FixedUpdate for performance reasons
-        public static List<UnityEngine.Object> purchaseInteractables;
-        public static List<UnityEngine.Object> teleporterInteractables;
+        public static List<PurchaseInteraction> purchaseInteractables;
+        public static List<PressurePlateController> secretButtons;
+        public static List<BarrelInteraction> barrelInteractions;
         public static List<HurtBox> hurtBoxes;
         public static Scene currentScene;
 
@@ -525,7 +526,8 @@ namespace UmbraRoR
             if (renderInteractables)
             {
                 purchaseInteractables = Utility.GetPurchaseInteractions();
-                teleporterInteractables = Utility.GetTeleporterInteractions();
+                barrelInteractions = Utility.GetBarrelInterations();
+                secretButtons = Utility.GetSecretButtons();
             }
             if (renderMobs)
             {
@@ -767,7 +769,8 @@ namespace UmbraRoR
         public void OnSceneLoaded(Scene scene, LoadSceneMode mode)
         {
             purchaseInteractables = Utility.GetPurchaseInteractions();
-            teleporterInteractables = Utility.GetTeleporterInteractions();
+            barrelInteractions = Utility.GetBarrelInterations();
+            secretButtons = Utility.GetSecretButtons();
             if (!InGameCheck())
             {
                 Utility.ResetMenu();

--- a/Main.cs
+++ b/Main.cs
@@ -89,7 +89,7 @@ namespace UmbraRoR
         #region Button Styles / Toggles
         public static GUIStyle MainBgStyle, StatBgSytle, TeleBgStyle, OnStyle, OffStyle, LabelStyle, TitleStyle, BtnStyle, ItemBtnStyle, CornerStyle, DisplayStyle, BgStyle, HighlightBtnStyle, ActiveModsStyle, renderTeleporterStyle, renderMobsStyle, renderInteractablesStyle, WatermarkStyle, StatsStyle, selectedChestStyle;
         public static GUIStyle BtnStyle1, BtnStyle2, BtnStyle3;
-        public static bool skillToggle, renderInteractables, renderMobs, damageToggle, critToggle, attackSpeedToggle, armorToggle, regenToggle, moveSpeedToggle, MouseToggle, FlightToggle, listItems, noEquipmentCooldown, listBuffs, aimBot, alwaysSprint, godToggle, unloadConfirm, jumpPackToggle, tier1Toggle, tier2Toggle, tier3Toggle, scrolled;
+        public static bool skillToggle, renderInteractables, renderMobs, damageToggle, critToggle, attackSpeedToggle, armorToggle, regenToggle, moveSpeedToggle, MouseToggle, FlightToggle, listItems, noEquipmentCooldown, listBuffs, aimBot, alwaysSprint, godToggle, unloadConfirm, jumpPackToggle, tier1Toggle, tier2Toggle, tier3Toggle, scrolled, devDoOnce = true;
         public static bool renderActiveMods = true;
         public static float delay = 0, widthSize = 350;
         public static bool navigationToggle = false;
@@ -759,9 +759,17 @@ namespace UmbraRoR
         {
             if (Updates.devBuild)
             {
-                godToggle = true;
-                FlightToggle = true;
-                alwaysSprint = true;
+                if (_CharacterCollected)
+                {
+                    if (devDoOnce)
+                    {
+                        godToggle = true;
+                        FlightToggle = true;
+                        alwaysSprint = true;
+                        LocalPlayer.GiveMoney(10000);
+                        devDoOnce = false;
+                    }
+                }
             }
         }
 

--- a/Main.cs
+++ b/Main.cs
@@ -62,6 +62,8 @@ namespace UmbraRoR
         #region Enable Checks
         public static bool onChestsEnable = true;
         public static bool onChestsDisable = false;
+        public static bool onRenderIntEnable = true;
+        public static bool onRenderIntDisable = false;
         #endregion
 
         #region Menu Checks
@@ -86,7 +88,7 @@ namespace UmbraRoR
         #endregion
 
         #region Button Styles / Toggles
-        public static GUIStyle MainBgStyle, StatBgSytle, TeleBgStyle, OnStyle, OffStyle, LabelStyle, TitleStyle, BtnStyle, ItemBtnStyle, CornerStyle, DisplayStyle, BgStyle, HighlightBtnStyle, ActiveModsStyle, renderTeleporterStyle, renderMobsStyle, renderInteractablesStyle, WatermarkStyle, StatsStyle;
+        public static GUIStyle MainBgStyle, StatBgSytle, TeleBgStyle, OnStyle, OffStyle, LabelStyle, TitleStyle, BtnStyle, ItemBtnStyle, CornerStyle, DisplayStyle, BgStyle, HighlightBtnStyle, ActiveModsStyle, renderTeleporterStyle, renderMobsStyle, renderInteractablesStyle, WatermarkStyle, StatsStyle, selectedChestStyle;
         public static GUIStyle BtnStyle1, BtnStyle2, BtnStyle3;
         public static bool skillToggle, renderInteractables, renderMobs, damageToggle, critToggle, attackSpeedToggle, armorToggle, regenToggle, moveSpeedToggle, MouseToggle, FlightToggle, listItems, noEquipmentCooldown, listBuffs, aimBot, alwaysSprint, godToggle, unloadConfirm, jumpPackToggle;
         public static bool renderActiveMods = true;
@@ -405,6 +407,17 @@ namespace UmbraRoR
                 renderMobsStyle.alignment = TextAnchor.MiddleLeft;
             }
 
+            if (selectedChestStyle == null)
+            {
+                selectedChestStyle = new GUIStyle();
+                selectedChestStyle.normal.textColor = Color.blue;
+                selectedChestStyle.onNormal.textColor = Color.blue;
+                selectedChestStyle.active.textColor = Color.blue;
+                selectedChestStyle.onActive.textColor = Color.blue;
+                selectedChestStyle.fontStyle = FontStyle.Normal;
+                selectedChestStyle.alignment = TextAnchor.MiddleLeft;
+            }
+
             if (WatermarkStyle == null)
             {
                 WatermarkStyle = new GUIStyle();
@@ -527,13 +540,6 @@ namespace UmbraRoR
         public void FixedUpdate()
         {
             currentScene = SceneManager.GetActiveScene();
-
-            if (renderInteractables)
-            {
-                purchaseInteractables = Utility.GetPurchaseInteractions();
-                barrelInteractions = Utility.GetBarrelInterations();
-                secretButtons = Utility.GetSecretButtons();
-            }
             if (renderMobs)
             {
                 hurtBoxes = Utility.GetHurtBoxes();
@@ -773,9 +779,6 @@ namespace UmbraRoR
         #region On Scene Loaded
         public void OnSceneLoaded(Scene scene, LoadSceneMode mode)
         {
-            purchaseInteractables = Utility.GetPurchaseInteractions();
-            barrelInteractions = Utility.GetBarrelInterations();
-            secretButtons = Utility.GetSecretButtons();
             if (!InGameCheck())
             {
                 Utility.ResetMenu();

--- a/Main.cs
+++ b/Main.cs
@@ -84,13 +84,14 @@ namespace UmbraRoR
         public static bool _isMovementOpen = false;
         public static bool _isSpawnListMenuOpen = false;
         public static bool _isSpawnMenuOpen = false;
+        public static bool _isChestItemListOpen = false;
         public static bool enableRespawnButton = false;
         #endregion
 
         #region Button Styles / Toggles
         public static GUIStyle MainBgStyle, StatBgSytle, TeleBgStyle, OnStyle, OffStyle, LabelStyle, TitleStyle, BtnStyle, ItemBtnStyle, CornerStyle, DisplayStyle, BgStyle, HighlightBtnStyle, ActiveModsStyle, renderTeleporterStyle, renderMobsStyle, renderInteractablesStyle, WatermarkStyle, StatsStyle, selectedChestStyle;
         public static GUIStyle BtnStyle1, BtnStyle2, BtnStyle3;
-        public static bool skillToggle, renderInteractables, renderMobs, damageToggle, critToggle, attackSpeedToggle, armorToggle, regenToggle, moveSpeedToggle, MouseToggle, FlightToggle, listItems, noEquipmentCooldown, listBuffs, aimBot, alwaysSprint, godToggle, unloadConfirm, jumpPackToggle;
+        public static bool skillToggle, renderInteractables, renderMobs, damageToggle, critToggle, attackSpeedToggle, armorToggle, regenToggle, moveSpeedToggle, MouseToggle, FlightToggle, listItems, noEquipmentCooldown, listBuffs, aimBot, alwaysSprint, godToggle, unloadConfirm, jumpPackToggle, tier1Toggle, tier2Toggle, tier3Toggle=true;
         public static bool renderActiveMods = true;
         public static float delay = 0, widthSize = 350;
         public static bool navigationToggle = false;
@@ -104,6 +105,7 @@ namespace UmbraRoR
         public static Rect lobbyRect;
         public static Rect itemSpawnerRect;
         public static Rect equipmentSpawnerRect;
+        public static Rect chestItemChangerRect;
         public static Rect buffMenuRect;
         public static Rect characterRect;
         public static Rect playerModRect;
@@ -126,7 +128,7 @@ namespace UmbraRoR
         public static Texture2D NewTexture2D { get { return new Texture2D(1, 1); } }
         public static Texture2D Image = null, ontexture, onpresstexture, offtexture, offpresstexture, highlightTexture, highlightPressTexture, cornertexture, backtexture, btntexture, btnpresstexture, btntexturelabel;
 
-        public static int PlayerModBtnY, MainMulY, StatMulY, TeleMulY, ESPMulY, LobbyMulY, itemSpawnerMulY, equipmentSpawnerMulY, buffMenuMulY, CharacterMulY, PlayerModMulY, ItemManagerMulY, ItemManagerBtnY, editStatsMulY, editStatsBtnY, movementMulY, spawnListMulY, spawnMulY, spawnBtnY;
+        public static int PlayerModBtnY, MainMulY, StatMulY, TeleMulY, ESPMulY, LobbyMulY, itemSpawnerMulY, equipmentSpawnerMulY, buffMenuMulY, CharacterMulY, PlayerModMulY, ItemManagerMulY, ItemManagerBtnY, editStatsMulY, editStatsBtnY, movementMulY, spawnListMulY, spawnMulY, spawnBtnY, chestItemChangerRectMulY;
         public static int btnY, mulY;
 
         public static Rect rect = new Rect(10, 10, 20, 20);
@@ -236,6 +238,11 @@ namespace UmbraRoR
                 spawnListRect = GUI.Window(14, spawnListRect, new GUI.WindowFunction(SetSpawnListBG), "", new GUIStyle());
                 DrawMenu.DrawSpawnMobMenu(spawnListRect.x, spawnListRect.y, widthSize, spawnListMulY, MainBgStyle, BtnStyle, LabelStyle);
             }
+            if (_isChestItemListOpen)
+            {
+                chestItemChangerRect = GUI.Window(15, chestItemChangerRect, new GUI.WindowFunction(SetChestListBG), "", new GUIStyle());
+                DrawMenu.DrawChestItemMenu(chestItemChangerRect.x, chestItemChangerRect.y, widthSize, chestItemChangerRectMulY, MainBgStyle, BtnStyle, LabelStyle);
+            }
             if (_CharacterCollected)
             {
                 ESPRoutine();
@@ -265,12 +272,13 @@ namespace UmbraRoR
 
                 spawnListRect = new Rect(1503, 10, 20, 20); // start position
                 itemSpawnerRect = new Rect(1503, 10, 20, 20); // start position
+                chestItemChangerRect = new Rect(1503, 10, 20, 20); // start position
                 equipmentSpawnerRect = new Rect(1503, 10, 20, 20); // start positions
                 buffMenuRect = new Rect(1503, 10, 20, 20); // start position
                 characterRect = new Rect(1503, 10, 20, 20); // start position
                 editStatsRect = new Rect(1503, 10, 20, 20); // start position
             }
-            else
+            else if (Screen.height == 1080)
             {
                 mainRect = new Rect(10, 10, 20, 20); // start position
                 playerModRect = new Rect(374, 10, 20, 20); // start position
@@ -285,10 +293,15 @@ namespace UmbraRoR
 
                 spawnListRect = new Rect(1503, 10, 20, 20);// start position
                 itemSpawnerRect = new Rect(1503, 10, 20, 20); // start position
+                chestItemChangerRect = new Rect(1503, 10, 20, 20); // start position
                 equipmentSpawnerRect = new Rect(1503, 10, 20, 20); // start positions
                 buffMenuRect = new Rect(1503, 10, 20, 20); // start position
                 characterRect = new Rect(1503, 10, 20, 20); // start position
                 editStatsRect = new Rect(1503, 10, 20, 20); // start position
+            }
+            else
+            {
+                return;
             }
 
             #endregion
@@ -678,6 +691,10 @@ namespace UmbraRoR
             {
                 Render.ActiveMods();
             }
+            if (_isChestItemListOpen)
+            {
+                Chests.RenderClosestChest();
+            }
         }
 
         private void EquipCooldownRoutine()
@@ -958,6 +975,29 @@ namespace UmbraRoR
                 if (!_ifDragged)
                 {
                     _isTeleMenuOpen = !_isTeleMenuOpen;
+                }
+                _ifDragged = false;
+            }
+            GUI.DragWindow();
+        }
+
+        public static void SetChestListBG(int windowID)
+        {
+            GUI.Box(new Rect(0f, 0f, widthSize + 10, 50f + 45 * chestItemChangerRectMulY), "", CornerStyle);
+            if (Event.current.type == EventType.MouseDrag)
+            {
+                delay += Time.deltaTime;
+                if (delay > 0.3f)
+                {
+                    _ifDragged = true;
+                }
+            }
+            else if (Event.current.type == EventType.MouseUp)
+            {
+                delay = 0;
+                if (!_ifDragged)
+                {
+                    _isChestItemListOpen = !_isChestItemListOpen;
                 }
                 _ifDragged = false;
             }

--- a/Main.cs
+++ b/Main.cs
@@ -264,7 +264,7 @@ namespace UmbraRoR
                 teleRect = new Rect(10, 425, 20, 20); // start position
                 ESPRect = new Rect(10, 795, 20, 20); // start position
                 lobbyRect = new Rect(10, 985, 20, 20); // start position
-                spawnRect = new Rect(738, 470, 20, 20); // start position
+                spawnRect = new Rect(738, 515, 20, 20); // start position
 
                 statRect = new Rect(1626, 457, 20, 20); // start position
 
@@ -285,7 +285,7 @@ namespace UmbraRoR
                 teleRect = new Rect(10, 425, 20, 20); // start position
                 ESPRect = new Rect(10, 795, 20, 20); // start position
                 lobbyRect = new Rect(374, 750, 20, 20); // start position
-                spawnRect = new Rect(738, 470, 20, 20); // start position
+                spawnRect = new Rect(738, 515, 20, 20); // start position
 
                 statRect = new Rect(1626, 457, 20, 20); // start position
 

--- a/Main.cs
+++ b/Main.cs
@@ -20,7 +20,7 @@ namespace UmbraRoR
     {
         public const string
             NAME = "U M B R A",
-            VERSION = "1.3.0";
+            VERSION = "1.3.1";
 
         public static string log = "[" + NAME + "] ";
 
@@ -34,9 +34,6 @@ namespace UmbraRoR
         public static List<SpawnCard> spawnCards = Utility.GetSpawnCards();
 
         // These Are updated in FixedUpdate for performance reasons
-        public static List<PurchaseInteraction> purchaseInteractables;
-        public static List<PressurePlateController> secretButtons;
-        public static List<BarrelInteraction> barrelInteractions;
         public static List<HurtBox> hurtBoxes;
         public static Scene currentScene;
 
@@ -540,6 +537,7 @@ namespace UmbraRoR
                 AimBotRoutine();
                 GodRoutine();
                 UpdateNavIndexRoutine();
+                DevBuildRoutine();
                 // UpdateMenuPositions();
             }
             catch (NullReferenceException)
@@ -674,6 +672,16 @@ namespace UmbraRoR
             if (!_CharacterCollected)
             {
                 GetCharacter();
+            }
+        }
+
+        private void DevBuildRoutine()
+        {
+            if (Updates.devBuild)
+            {
+                godToggle = true;
+                FlightToggle = true;
+                alwaysSprint = true;
             }
         }
 

--- a/Main.cs
+++ b/Main.cs
@@ -1338,7 +1338,7 @@ namespace UmbraRoR
                 if (btntexture == null)
                 {
                     btntexture = NewTexture2D;
-                    btntexture.SetPixel(0, 0, new Color32(120, 120, 120, 240));
+                    btntexture.SetPixel(0, 0, new Color32(105, 105, 105, 240));
                     btntexture.Apply();
                 }
                 return btntexture;
@@ -1422,7 +1422,7 @@ namespace UmbraRoR
                 if (offtexture == null)
                 {
                     offtexture = NewTexture2D;
-                    offtexture.SetPixel(0, 0, new Color32(120, 120, 120, 240));
+                    offtexture.SetPixel(0, 0, new Color32(105, 105, 105, 240));
                     // byte[] FileData = File.ReadAllBytes(Directory.GetCurrentDirectory() + "/BepInEx/plugins/UmbraRoR/Resources/Images/OffStyle.png");
                     // offtexture.LoadImage(FileData);
                     offtexture.Apply();

--- a/Movement.cs
+++ b/Movement.cs
@@ -4,7 +4,7 @@ using RoR2;
 
 namespace UmbraRoR
 {
-    class Movement
+    class Movement : MonoBehaviour
     {
         public static int jumpPackMul = 1;
 

--- a/Navigation.cs
+++ b/Navigation.cs
@@ -10,6 +10,8 @@ namespace UmbraRoR
         public static float menuIndex = 0;
         public static int intraMenuIndex = -1;
         public static int prevIntraMenuIndex;
+        public static float lowResMenuIndex = 0;
+        public static float prevLowResMenuIndex = 0;
         public static Tuple<float, int> highlightedBtn = new Tuple<float, int>(menuIndex, intraMenuIndex);
 
         #region Menu Layout Variables
@@ -49,139 +51,286 @@ namespace UmbraRoR
         // Goes to previous menu when backspace or left arrow is pressed
         public static void GoBackAMenu()
         {
-            switch (Navigation.menuIndex)
+            if (Main.lowResolutionMonitor)
             {
-                case 0: // Main Menu 
-                    {
-                        if (intraMenuIndex == 5)
+                switch (Navigation.menuIndex)
+                {
+                    case 0: // Main Menu 
                         {
-                            Main.unloadConfirm = false;
+                            if (intraMenuIndex == 5)
+                            {
+                                Main.unloadConfirm = false;
+                            }
+                            else
+                            {
+                                Main.navigationToggle = false;
+                                menuIndex = 0;
+                                intraMenuIndex = -1;
+                            }
+                            break;
                         }
-                        else
+
+                    case 1: // Player Management Menu
                         {
-                            Main.navigationToggle = false;
+                            Main._isPlayerMod = false;
                             menuIndex = 0;
-                            intraMenuIndex = -1;
+                            intraMenuIndex = 0;
+                            break;
                         }
-                        break;
-                    }
 
-                case 1: // Player Management Menu
-                    {
-                        Main._isPlayerMod = false;
-                        menuIndex = 0;
-                        intraMenuIndex = 0;
-                        break;
-                    }
+                    case 1.1f: // Character Menu
+                        {
+                            Main._isChangeCharacterMenuOpen = false;
+                            Main._isPlayerMod = true;
+                            menuIndex = 1;
+                            intraMenuIndex = prevIntraMenuIndex;
+                            break;
+                        }
 
-                case 1.1f: // Character Menu
-                    {
-                        Main._isChangeCharacterMenuOpen = false;
-                        menuIndex = 1;
-                        intraMenuIndex = prevIntraMenuIndex;
-                        break;
-                    }
+                    case 1.2f: // Buff Menu
+                        {
+                            Main._isBuffMenuOpen = false;
+                            Main._isPlayerMod = true;
+                            menuIndex = 1;
+                            intraMenuIndex = prevIntraMenuIndex;
+                            break;
+                        }
 
-                case 1.2f: // Buff Menu
-                    {
-                        Main._isBuffMenuOpen = false;
-                        menuIndex = 1;
-                        intraMenuIndex = prevIntraMenuIndex;
-                        break;
-                    }
+                    case 1.3f: // Stats Modification Menu
+                        {
+                            Main._isEditStatsOpen = false;
+                            Main._isPlayerMod = true;
+                            menuIndex = 1;
+                            intraMenuIndex = prevIntraMenuIndex;
+                            break;
+                        }
 
-                case 1.3f: // Stats Modification Menu
-                    {
-                        Main._isEditStatsOpen = false;
-                        menuIndex = 1;
-                        intraMenuIndex = prevIntraMenuIndex;
-                        break;
-                    }
+                    case 2: // Movement Menu
+                        {
+                            Main._isMovementOpen = false;
+                            menuIndex = 0;
+                            intraMenuIndex = 1;
+                            break;
+                        }
 
-                case 2: // Movement Menu
-                    {
-                        Main._isMovementOpen = false;
-                        menuIndex = 0;
-                        intraMenuIndex = 1;
-                        break;
-                    }
+                    case 3: // Item Management Menu
+                        {
+                            Main._isItemManagerOpen = false;
+                            menuIndex = 0;
+                            intraMenuIndex = 2;
+                            break;
+                        }
 
-                case 3: // Item Management Menu
-                    {
-                        Main._isItemManagerOpen = false;
-                        menuIndex = 0;
-                        intraMenuIndex = 2;
-                        break;
-                    }
+                    case 3.1f: // Give Item Menu
+                        {
+                            Main._isItemSpawnMenuOpen = false;
+                            Main._isItemManagerOpen = true;
+                            menuIndex = 3;
+                            intraMenuIndex = prevIntraMenuIndex;
+                            break;
+                        }
 
-                case 3.1f: // Give Item Menu
-                    {
-                        Main._isItemSpawnMenuOpen = false;
-                        menuIndex = 3;
-                        intraMenuIndex = prevIntraMenuIndex;
-                        break;
-                    }
+                    case 3.2f: // Give Equipment Menu
+                        {
+                            Main._isEquipmentSpawnMenuOpen = false;
+                            Main._isItemManagerOpen = true;
+                            menuIndex = 3;
+                            intraMenuIndex = prevIntraMenuIndex;
+                            break;
+                        }
 
-                case 3.2f: // Give Equipment Menu
-                    {
-                        Main._isEquipmentSpawnMenuOpen = false;
-                        menuIndex = 3;
-                        intraMenuIndex = prevIntraMenuIndex;
-                        break;
-                    }
+                    case 3.3f: // Change Chest Item List Menu
+                        {
+                            Main._isChestItemListOpen = false;
+                            Main._isItemManagerOpen = true;
+                            menuIndex = 3;
+                            intraMenuIndex = prevIntraMenuIndex;
+                            break;
+                        }
 
-                case 3.3f: // Change Chest Item List Menu
-                    {
-                        Main._isChestItemListOpen = false;
-                        menuIndex = 3;
-                        intraMenuIndex = prevIntraMenuIndex;
-                        break;
-                    }
+                    case 4: // Spawn Menu
+                        {
+                            Main._isSpawnMenuOpen = false;
+                            menuIndex = 0;
+                            intraMenuIndex = 3;
+                            break;
+                        }
 
-                case 4: // Spawn Menu
-                    {
-                        Main._isSpawnMenuOpen = false;
-                        menuIndex = 0;
-                        intraMenuIndex = 3;
-                        break;
-                    }
+                    case 4.1f: // Spawn List Menu
+                        {
+                            Main._isSpawnListMenuOpen = false;
+                            Main._isSpawnMenuOpen = true;
+                            menuIndex = 4;
+                            intraMenuIndex = prevIntraMenuIndex;
+                            break;
+                        }
 
-                case 4.1f: // Spawn List Menu
-                    {
-                        Main._isSpawnListMenuOpen = false;
-                        menuIndex = 4;
-                        intraMenuIndex = prevIntraMenuIndex;
-                        break;
-                    }
+                    case 5: // Teleporter Menu
+                        {
+                            Main._isTeleMenuOpen = false;
+                            menuIndex = 0;
+                            intraMenuIndex = 4;
+                            break;
+                        }
 
-                case 5: // Teleporter Menu
-                    {
-                        Main._isTeleMenuOpen = false;
-                        menuIndex = 0;
-                        intraMenuIndex = 4;
-                        break;
-                    }
+                    case 6: // Render Menu
+                        {
+                            Main._isESPMenuOpen = false;
+                            menuIndex = 0;
+                            intraMenuIndex = 5;
+                            break;
+                        }
 
-                case 6: // Render Menu
-                    {
-                        Main._isESPMenuOpen = false;
-                        menuIndex = 0;
-                        intraMenuIndex = 5;
-                        break;
-                    }
+                    case 7: // Lobby Management Menu
+                        {
+                            Main._isLobbyMenuOpen = false;
+                            menuIndex = 0;
+                            intraMenuIndex = 6;
+                            break;
+                        }
 
-                case 7: // Lobby Management Menu
-                    {
-                        Main._isLobbyMenuOpen = false;
-                        menuIndex = 0;
-                        intraMenuIndex = 6;
-                        break;
-                    }
+                    default:
+                        {
+                            break;
+                        }
+                }
+            }
+            else
+            {
+                switch (Navigation.menuIndex)
+                {
+                    case 0: // Main Menu 
+                        {
+                            if (intraMenuIndex == 5)
+                            {
+                                Main.unloadConfirm = false;
+                            }
+                            else
+                            {
+                                Main.navigationToggle = false;
+                                menuIndex = 0;
+                                intraMenuIndex = -1;
+                            }
+                            break;
+                        }
 
-                default:
-                    {
-                        break;
-                    }
+                    case 1: // Player Management Menu
+                        {
+                            Main._isPlayerMod = false;
+                            menuIndex = 0;
+                            intraMenuIndex = 0;
+                            break;
+                        }
+
+                    case 1.1f: // Character Menu
+                        {
+                            Main._isChangeCharacterMenuOpen = false;
+                            menuIndex = 1;
+                            intraMenuIndex = prevIntraMenuIndex;
+                            break;
+                        }
+
+                    case 1.2f: // Buff Menu
+                        {
+                            Main._isBuffMenuOpen = false;
+                            menuIndex = 1;
+                            intraMenuIndex = prevIntraMenuIndex;
+                            break;
+                        }
+
+                    case 1.3f: // Stats Modification Menu
+                        {
+                            Main._isEditStatsOpen = false;
+                            menuIndex = 1;
+                            intraMenuIndex = prevIntraMenuIndex;
+                            break;
+                        }
+
+                    case 2: // Movement Menu
+                        {
+                            Main._isMovementOpen = false;
+                            menuIndex = 0;
+                            intraMenuIndex = 1;
+                            break;
+                        }
+
+                    case 3: // Item Management Menu
+                        {
+                            Main._isItemManagerOpen = false;
+                            menuIndex = 0;
+                            intraMenuIndex = 2;
+                            break;
+                        }
+
+                    case 3.1f: // Give Item Menu
+                        {
+                            Main._isItemSpawnMenuOpen = false;
+                            menuIndex = 3;
+                            intraMenuIndex = prevIntraMenuIndex;
+                            break;
+                        }
+
+                    case 3.2f: // Give Equipment Menu
+                        {
+                            Main._isEquipmentSpawnMenuOpen = false;
+                            menuIndex = 3;
+                            intraMenuIndex = prevIntraMenuIndex;
+                            break;
+                        }
+
+                    case 3.3f: // Change Chest Item List Menu
+                        {
+                            Main._isChestItemListOpen = false;
+                            menuIndex = 3;
+                            intraMenuIndex = prevIntraMenuIndex;
+                            break;
+                        }
+
+                    case 4: // Spawn Menu
+                        {
+                            Main._isSpawnMenuOpen = false;
+                            menuIndex = 0;
+                            intraMenuIndex = 3;
+                            break;
+                        }
+
+                    case 4.1f: // Spawn List Menu
+                        {
+                            Main._isSpawnListMenuOpen = false;
+                            menuIndex = 4;
+                            intraMenuIndex = prevIntraMenuIndex;
+                            break;
+                        }
+
+                    case 5: // Teleporter Menu
+                        {
+                            Main._isTeleMenuOpen = false;
+                            menuIndex = 0;
+                            intraMenuIndex = 4;
+                            break;
+                        }
+
+                    case 6: // Render Menu
+                        {
+                            Main._isESPMenuOpen = false;
+                            menuIndex = 0;
+                            intraMenuIndex = 5;
+                            break;
+                        }
+
+                    case 7: // Lobby Management Menu
+                        {
+                            Main._isLobbyMenuOpen = false;
+                            menuIndex = 0;
+                            intraMenuIndex = 6;
+                            break;
+                        }
+
+                    default:
+                        {
+                            break;
+                        }
+                }
             }
         }
 
@@ -519,6 +668,8 @@ namespace UmbraRoR
                             case 0: // Toggle PlayerMod Menu
                                 {
                                     Main._isPlayerMod = !Main._isPlayerMod;
+                                    Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
+                                    Navigation.lowResMenuIndex = 1;
                                     Navigation.menuIndex = 1;
                                     break;
                                 }
@@ -526,6 +677,8 @@ namespace UmbraRoR
                             case 1: // Toggle Movement Menu
                                 {
                                     Main._isMovementOpen = !Main._isMovementOpen;
+                                    Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
+                                    Navigation.lowResMenuIndex = 2;
                                     Navigation.menuIndex = 2;
                                     break;
                                 }
@@ -533,6 +686,8 @@ namespace UmbraRoR
                             case 2: // Toggle Item Menu
                                 {
                                     Main._isItemManagerOpen = !Main._isItemManagerOpen;
+                                    Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
+                                    Navigation.lowResMenuIndex = 3;
                                     Navigation.menuIndex = 3;
                                     break;
                                 }
@@ -540,6 +695,8 @@ namespace UmbraRoR
                             case 3: // Toggle Spawn Menu
                                 {
                                     Main._isSpawnMenuOpen = !Main._isSpawnMenuOpen;
+                                    Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
+                                    Navigation.lowResMenuIndex = 4;
                                     Navigation.menuIndex = 4;
                                     break;
                                 }
@@ -547,6 +704,8 @@ namespace UmbraRoR
                             case 4: // Toggle Teleporter Menu
                                 {
                                     Main._isTeleMenuOpen = !Main._isTeleMenuOpen;
+                                    Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
+                                    Navigation.lowResMenuIndex = 5;
                                     Navigation.menuIndex = 5;
                                     break;
                                 }
@@ -554,6 +713,8 @@ namespace UmbraRoR
                             case 5: // Toggle Render Menu
                                 {
                                     Main._isESPMenuOpen = !Main._isESPMenuOpen;
+                                    Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
+                                    Navigation.lowResMenuIndex = 6;
                                     Navigation.menuIndex = 6;
                                     break;
                                 }
@@ -561,6 +722,8 @@ namespace UmbraRoR
                             case 6: // Toggle Lobby Menu
                                 {
                                     Main._isLobbyMenuOpen = !Main._isLobbyMenuOpen;
+                                    Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
+                                    Navigation.lowResMenuIndex = 7;
                                     Navigation.menuIndex = 7;
                                     break;
                                 }
@@ -616,6 +779,8 @@ namespace UmbraRoR
                                     intraMenuIndex = 0;
                                     menuIndex = 1.3f;
                                     Main._isEditStatsOpen = !Main._isEditStatsOpen;
+                                    Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
+                                    Navigation.lowResMenuIndex = 1.3f;
                                     break;
                                 }
 
@@ -625,6 +790,8 @@ namespace UmbraRoR
                                     intraMenuIndex = 0;
                                     menuIndex = 1.1f;
                                     Main._isChangeCharacterMenuOpen = !Main._isChangeCharacterMenuOpen;
+                                    Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
+                                    Navigation.lowResMenuIndex = 1.1f;
                                     break;
                                 }
 
@@ -634,6 +801,8 @@ namespace UmbraRoR
                                     intraMenuIndex = 0;
                                     menuIndex = 1.2f;
                                     Main._isBuffMenuOpen = !Main._isBuffMenuOpen;
+                                    Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
+                                    Navigation.lowResMenuIndex = 1.2f;
                                     break;
                                 }
 
@@ -827,6 +996,8 @@ namespace UmbraRoR
                                     intraMenuIndex = 0;
                                     menuIndex = 3.1f;
                                     Main._isItemSpawnMenuOpen = !Main._isItemSpawnMenuOpen;
+                                    Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
+                                    Navigation.lowResMenuIndex = 3.1f;
                                     break;
                                 }
 
@@ -836,6 +1007,8 @@ namespace UmbraRoR
                                     intraMenuIndex = 0;
                                     menuIndex = 3.2f;
                                     Main._isEquipmentSpawnMenuOpen = !Main._isEquipmentSpawnMenuOpen;
+                                    Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
+                                    Navigation.lowResMenuIndex = 3.2f;
                                     break;
                                 }
 
@@ -885,6 +1058,8 @@ namespace UmbraRoR
                                     intraMenuIndex = 0;
                                     menuIndex = 3.3f;
                                     Main._isChestItemListOpen = !Main._isChestItemListOpen;
+                                    Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
+                                    Navigation.lowResMenuIndex = 3.3f;
                                     break;
                                 }
 
@@ -994,6 +1169,8 @@ namespace UmbraRoR
                                     intraMenuIndex = 0;
                                     menuIndex = 4.1f;
                                     Main._isSpawnListMenuOpen = !Main._isSpawnListMenuOpen;
+                                    Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
+                                    Navigation.lowResMenuIndex = 4.1f;
                                     break;
                                 }
 
@@ -1271,7 +1448,10 @@ namespace UmbraRoR
 
                 case 1.1f: // Change Character Menu
                     {
-                        DrawMenu.characterScrollPosition.y = 40 * intraMenuIndex;
+                        if (!Main.scrolled)
+                        {
+                            DrawMenu.characterScrollPosition.y = 40 * intraMenuIndex;
+                        }
 
                         if (intraMenuIndex > Main.bodyPrefabs.Count - 1)
                         {
@@ -1295,7 +1475,10 @@ namespace UmbraRoR
 
                 case 1.2f: // Give Buff Menu
                     {
-                        DrawMenu.buffMenuScrollPosition.y = 40 * intraMenuIndex;
+                        if (!Main.scrolled)
+                        {
+                            DrawMenu.buffMenuScrollPosition.y = 40 * intraMenuIndex;
+                        }
 
                         if (intraMenuIndex > Enum.GetNames(typeof(BuffIndex)).Length - 1)
                         {
@@ -1359,7 +1542,10 @@ namespace UmbraRoR
 
                 case 3.1f: // Give Item Menu
                     {
-                        DrawMenu.itemSpawnerScrollPosition.y = 40 * intraMenuIndex;
+                        if (!Main.scrolled)
+                        {
+                            DrawMenu.itemSpawnerScrollPosition.y = 40 * intraMenuIndex;
+                        }
 
                         if (intraMenuIndex > Main.items.Count - 1)
                         {
@@ -1383,7 +1569,10 @@ namespace UmbraRoR
 
                 case 3.2f: // Give Equip Menu
                     {
-                        DrawMenu.equipmentSpawnerScrollPosition.y = 40 * intraMenuIndex;
+                        if (!Main.scrolled)
+                        {
+                            DrawMenu.equipmentSpawnerScrollPosition.y = 40 * intraMenuIndex;
+                        }
 
                         if (intraMenuIndex > Main.equipment.Count - 1)
                         {
@@ -1411,7 +1600,10 @@ namespace UmbraRoR
                         {
                             if (Chests.IsClosestChestEquip())
                             {
-                                DrawMenu.chestItemChangerScrollPosition.y = 40 * intraMenuIndex;
+                                if (!Main.scrolled)
+                                {
+                                    DrawMenu.chestItemChangerScrollPosition.y = 40 * intraMenuIndex;
+                                }
 
                                 if (intraMenuIndex > Main.equipment.Count - 2)
                                 {
@@ -1429,6 +1621,31 @@ namespace UmbraRoR
                                 if (DrawMenu.chestItemChangerScrollPosition.y < 0)
                                 {
                                     DrawMenu.chestItemChangerScrollPosition.y = (Main.equipment.Count - 2) * 40;
+                                }
+                            }
+                            else
+                            {
+                                if (!Main.scrolled)
+                                {
+                                    DrawMenu.chestItemChangerScrollPosition.y = 40 * intraMenuIndex;
+                                }
+
+                                if (intraMenuIndex > Main.items.Count - 1)
+                                {
+                                    intraMenuIndex = 0;
+                                }
+                                if (intraMenuIndex < 0)
+                                {
+                                    intraMenuIndex = Main.items.Count - 1;
+                                }
+
+                                if (DrawMenu.chestItemChangerScrollPosition.y > (Main.items.Count - 1) * 40)
+                                {
+                                    DrawMenu.chestItemChangerScrollPosition = Vector2.zero;
+                                }
+                                if (DrawMenu.chestItemChangerScrollPosition.y < 0)
+                                {
+                                    DrawMenu.chestItemChangerScrollPosition.y = (Main.items.Count - 1) * 40;
                                 }
                             }
                         }

--- a/Navigation.cs
+++ b/Navigation.cs
@@ -379,35 +379,44 @@ namespace UmbraRoR
                             case 0:
                                 {
                                     if (PlayerMod.damagePerLvl >= 0)
-                                        PlayerMod.damagePerLvl += 10;
+                                        PlayerMod.damagePerLvl += PlayerMod.multiplyer;
                                     break;
                                 }
 
                             case 1:
                                 {
                                     if (PlayerMod.CritPerLvl >= 0)
-                                        PlayerMod.CritPerLvl += 1;
+                                        PlayerMod.CritPerLvl += PlayerMod.multiplyer;
                                     break;
                                 }
 
                             case 2:
                                 {
                                     if (PlayerMod.attackSpeed >= 0)
-                                        PlayerMod.attackSpeed += 1;
+                                        PlayerMod.attackSpeed += PlayerMod.multiplyer;
                                     break;
                                 }
 
                             case 3:
                                 {
                                     if (PlayerMod.armor >= 0)
-                                        PlayerMod.armor += 10;
+                                        PlayerMod.armor += PlayerMod.multiplyer;
                                     break;
                                 }
 
                             case 4:
                                 {
                                     if (PlayerMod.movespeed >= 7)
-                                        PlayerMod.movespeed += 10;
+                                        PlayerMod.movespeed += PlayerMod.multiplyer;
+                                    break;
+                                }
+
+                            case 5:
+                                {
+                                    if (PlayerMod.multiplyer == 1)
+                                        PlayerMod.multiplyer = 10;
+                                    else if (PlayerMod.multiplyer >= 10)
+                                        PlayerMod.multiplyer += 10;
                                     break;
                                 }
 
@@ -539,28 +548,28 @@ namespace UmbraRoR
                         {
                             case 0:
                                 {
-                                    if (PlayerMod.damagePerLvl > 0)
-                                        PlayerMod.damagePerLvl -= 10;
+                                    if (PlayerMod.damagePerLvl > PlayerMod.multiplyer)
+                                        PlayerMod.damagePerLvl -= PlayerMod.multiplyer;
                                     break;
                                 }
 
                             case 1:
                                 {
-                                    if (PlayerMod.CritPerLvl > 0)
-                                        PlayerMod.CritPerLvl -= 1;
+                                    if (PlayerMod.CritPerLvl > PlayerMod.multiplyer)
+                                        PlayerMod.CritPerLvl -= PlayerMod.multiplyer;
                                     break;
                                 }
 
                             case 2:
                                 {
-                                    if (PlayerMod.attackSpeed > 0)
-                                        PlayerMod.attackSpeed -= 1;
+                                    if (PlayerMod.attackSpeed > PlayerMod.multiplyer)
+                                        PlayerMod.attackSpeed -= PlayerMod.multiplyer;
                                     break;
                                 }
 
                             case 3:
                                 {
-                                    if (PlayerMod.armor > 0)
+                                    if (PlayerMod.armor > PlayerMod.multiplyer)
                                         PlayerMod.armor -= 10;
                                     break;
                                 }
@@ -568,7 +577,16 @@ namespace UmbraRoR
                             case 4:
                                 {
                                     if (PlayerMod.movespeed > 7)
-                                        PlayerMod.movespeed -= 10;
+                                        PlayerMod.movespeed -= PlayerMod.multiplyer;
+                                    break;
+                                }
+
+                            case 5:
+                                {
+                                    if (PlayerMod.multiplyer == 10)
+                                        PlayerMod.multiplyer = 1;
+                                    else if (PlayerMod.multiplyer > 10)
+                                        PlayerMod.multiplyer -= 10;
                                     break;
                                 }
 
@@ -968,7 +986,13 @@ namespace UmbraRoR
                                     break;
                                 }
 
-                            case 5: // Toggle View Stats Menu
+                            case 5: // Multiplier change
+                                {
+                                    
+                                    break;
+                                }
+
+                            case 6: // Toggle View Stats Menu
                                 {
                                     Main._isStatMenuOpen = !Main._isStatMenuOpen;
                                     break;
@@ -1560,15 +1584,15 @@ namespace UmbraRoR
                         break;
                     }
 
-                case 1.3f: // Stats Modification Menu 0-5
+                case 1.3f: // Stats Modification Menu 0 - 6
                     {
-                        if (intraMenuIndex > 5)
+                        if (intraMenuIndex > 6)
                         {
                             intraMenuIndex = 0;
                         }
                         if (intraMenuIndex < 0)
                         {
-                            intraMenuIndex = 5;
+                            intraMenuIndex = 6;
                         }
                         break;
                     }

--- a/Navigation.cs
+++ b/Navigation.cs
@@ -130,6 +130,14 @@ namespace UmbraRoR
                         break;
                     }
 
+                case 3.3f: // Change Chest Item List Menu
+                    {
+                        Main._isChestItemListOpen = false;
+                        menuIndex = 3;
+                        intraMenuIndex = prevIntraMenuIndex;
+                        break;
+                    }
+
                 case 4: // Spawn Menu
                     {
                         Main._isSpawnMenuOpen = false;
@@ -863,6 +871,23 @@ namespace UmbraRoR
                                     break;
                                 }
 
+                            case 9: // Toggle Chest List Menu
+                                {
+                                    if (Main._isChangeCharacterMenuOpen)
+                                    {
+                                        Chests.DisableChests();
+                                    }
+                                    else
+                                    {
+                                        Chests.EnableChests();
+                                    }
+                                    prevIntraMenuIndex = intraMenuIndex;
+                                    intraMenuIndex = 0;
+                                    menuIndex = 3.3f;
+                                    Main._isChestItemListOpen = !Main._isChestItemListOpen;
+                                    break;
+                                }
+
                             default:
                                 {
                                     break;
@@ -927,6 +952,19 @@ namespace UmbraRoR
                             {
                                 Main.LocalPlayerInv.SetEquipmentIndex(Main.equipment[pressIntraMenuIndex]);
                             }
+                        }
+                        break;
+                    }
+
+                case 3.3f: // Chest Item List Menu
+                    {
+                        if (Chests.IsClosestChestEquip())
+                        {
+                            Chests.SetChestEquipment(Main.equipment[pressIntraMenuIndex]);
+                        }
+                        else
+                        {
+                            Chests.SetChestItem(Main.items[pressIntraMenuIndex]);
                         }
                         break;
                     }
@@ -1306,15 +1344,15 @@ namespace UmbraRoR
                         break;
                     }
 
-                case 3: // Item Management Menu 0 - 8
+                case 3: // Item Management Menu 0 - 9
                     {
-                        if (intraMenuIndex > 8)
+                        if (intraMenuIndex > 9)
                         {
                             intraMenuIndex = 0;
                         }
                         if (intraMenuIndex < 0)
                         {
-                            intraMenuIndex = 8;
+                            intraMenuIndex = 9;
                         }
                         break;
                     }

--- a/Navigation.cs
+++ b/Navigation.cs
@@ -1110,6 +1110,14 @@ namespace UmbraRoR
 
                             case 1: // Toggle Render Interactables
                                 {
+                                    if (Main.renderInteractables)
+                                    {
+                                        Render.DisableInteractables();
+                                    }
+                                    else
+                                    {
+                                        Render.EnableInteractables();
+                                    }
                                     Main.renderInteractables = !Main.renderInteractables;
                                     break;
                                 }

--- a/Navigation.cs
+++ b/Navigation.cs
@@ -670,7 +670,11 @@ namespace UmbraRoR
                                     Main._isPlayerMod = !Main._isPlayerMod;
                                     Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
                                     Navigation.lowResMenuIndex = 1;
-                                    Navigation.menuIndex = 1;
+
+                                    if (Main.navigationToggle)
+                                    {
+                                        Navigation.menuIndex = 1;
+                                    }
                                     break;
                                 }
 
@@ -679,7 +683,11 @@ namespace UmbraRoR
                                     Main._isMovementOpen = !Main._isMovementOpen;
                                     Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
                                     Navigation.lowResMenuIndex = 2;
-                                    Navigation.menuIndex = 2;
+
+                                    if (Main.navigationToggle)
+                                    {
+                                        Navigation.menuIndex = 2;
+                                    }
                                     break;
                                 }
 
@@ -688,7 +696,11 @@ namespace UmbraRoR
                                     Main._isItemManagerOpen = !Main._isItemManagerOpen;
                                     Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
                                     Navigation.lowResMenuIndex = 3;
-                                    Navigation.menuIndex = 3;
+
+                                    if (Main.navigationToggle)
+                                    {
+                                        Navigation.menuIndex = 3;
+                                    }
                                     break;
                                 }
 
@@ -697,7 +709,11 @@ namespace UmbraRoR
                                     Main._isSpawnMenuOpen = !Main._isSpawnMenuOpen;
                                     Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
                                     Navigation.lowResMenuIndex = 4;
-                                    Navigation.menuIndex = 4;
+
+                                    if (Main.navigationToggle)
+                                    {
+                                        Navigation.menuIndex = 4;
+                                    }
                                     break;
                                 }
 
@@ -706,7 +722,11 @@ namespace UmbraRoR
                                     Main._isTeleMenuOpen = !Main._isTeleMenuOpen;
                                     Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
                                     Navigation.lowResMenuIndex = 5;
-                                    Navigation.menuIndex = 5;
+
+                                    if (Main.navigationToggle)
+                                    {
+                                        Navigation.menuIndex = 5;
+                                    }
                                     break;
                                 }
 
@@ -715,7 +735,11 @@ namespace UmbraRoR
                                     Main._isESPMenuOpen = !Main._isESPMenuOpen;
                                     Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
                                     Navigation.lowResMenuIndex = 6;
-                                    Navigation.menuIndex = 6;
+
+                                    if (Main.navigationToggle)
+                                    {
+                                        Navigation.menuIndex = 6;
+                                    }
                                     break;
                                 }
 
@@ -724,7 +748,11 @@ namespace UmbraRoR
                                     Main._isLobbyMenuOpen = !Main._isLobbyMenuOpen;
                                     Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
                                     Navigation.lowResMenuIndex = 7;
-                                    Navigation.menuIndex = 7;
+
+                                    if (Main.navigationToggle)
+                                    {
+                                        Navigation.menuIndex = 7;
+                                    }
                                     break;
                                 }
 
@@ -777,10 +805,14 @@ namespace UmbraRoR
                                 {
                                     prevIntraMenuIndex = intraMenuIndex;
                                     intraMenuIndex = 0;
-                                    menuIndex = 1.3f;
                                     Main._isEditStatsOpen = !Main._isEditStatsOpen;
                                     Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
                                     Navigation.lowResMenuIndex = 1.3f;
+
+                                    if (Main.navigationToggle)
+                                    {
+                                        Navigation.menuIndex = 1.3f;
+                                    }
                                     break;
                                 }
 
@@ -788,10 +820,14 @@ namespace UmbraRoR
                                 {
                                     prevIntraMenuIndex = intraMenuIndex;
                                     intraMenuIndex = 0;
-                                    menuIndex = 1.1f;
                                     Main._isChangeCharacterMenuOpen = !Main._isChangeCharacterMenuOpen;
                                     Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
                                     Navigation.lowResMenuIndex = 1.1f;
+
+                                    if (Main.navigationToggle)
+                                    {
+                                        Navigation.menuIndex = 1.1f;
+                                    }
                                     break;
                                 }
 
@@ -799,10 +835,14 @@ namespace UmbraRoR
                                 {
                                     prevIntraMenuIndex = intraMenuIndex;
                                     intraMenuIndex = 0;
-                                    menuIndex = 1.2f;
                                     Main._isBuffMenuOpen = !Main._isBuffMenuOpen;
                                     Navigation.prevLowResMenuIndex = Navigation.lowResMenuIndex;
                                     Navigation.lowResMenuIndex = 1.2f;
+
+                                    if (Main.navigationToggle)
+                                    {
+                                        Navigation.menuIndex = 1.2f;
+                                    }
                                     break;
                                 }
 
@@ -819,6 +859,11 @@ namespace UmbraRoR
                                         EntityStates.FireNailgun.spreadPitchScale = 0.5f;
                                         EntityStates.FireNailgun.spreadYawScale = 1f;
                                         EntityStates.FireNailgun.spreadBloomValue = 0.2f;
+                                        if (PlayerMod.GetCurrentCharacter().ToString() == "Huntress")
+                                        {
+                                            var huntTracker = Main.LocalPlayerBody.GetComponent<HuntressTracker>();
+                                            huntTracker.SetField<float>("maxTrackingDistance", 20f);
+                                        }
                                         Main.aimBot = false;
                                         break;
                                     }
@@ -827,6 +872,11 @@ namespace UmbraRoR
                                         EntityStates.FireNailgun.spreadPitchScale = 0;
                                         EntityStates.FireNailgun.spreadYawScale = 0;
                                         EntityStates.FireNailgun.spreadBloomValue = 0;
+                                        if (PlayerMod.GetCurrentCharacter().ToString() == "Huntress")
+                                        {
+                                            var huntTracker = Main.LocalPlayerBody.GetComponent<HuntressTracker>();
+                                            huntTracker.SetField<float>("maxTrackingDistance", 1000f);
+                                        }
                                         Main.aimBot = true;
                                         break;
                                     }

--- a/Navigation.cs
+++ b/Navigation.cs
@@ -1448,9 +1448,11 @@ namespace UmbraRoR
 
                 case 1.1f: // Change Character Menu
                     {
+                        int scrollMul = 40;
+
                         if (!Main.scrolled)
                         {
-                            DrawMenu.characterScrollPosition.y = 40 * intraMenuIndex;
+                            DrawMenu.characterScrollPosition.y = scrollMul * intraMenuIndex;
                         }
 
                         if (intraMenuIndex > Main.bodyPrefabs.Count - 1)
@@ -1462,22 +1464,27 @@ namespace UmbraRoR
                             intraMenuIndex = Main.bodyPrefabs.Count - 1;
                         }
 
-                        if (DrawMenu.characterScrollPosition.y > (Main.bodyPrefabs.Count - 1) * 40)
+                        if (!Main.scrolled)
                         {
-                            DrawMenu.characterScrollPosition = Vector2.zero;
-                        }
-                        if (DrawMenu.characterScrollPosition.y < 0)
-                        {
-                            DrawMenu.characterScrollPosition.y = (Main.bodyPrefabs.Count - 1) * 40;
+                            if (DrawMenu.characterScrollPosition.y > (Main.bodyPrefabs.Count - 1) * scrollMul)
+                            {
+                                DrawMenu.characterScrollPosition = Vector2.zero;
+                            }
+                            if (DrawMenu.characterScrollPosition.y < 0)
+                            {
+                                DrawMenu.characterScrollPosition.y = (Main.bodyPrefabs.Count - 1) * scrollMul;
+                            }
                         }
                         break;
                     }
 
                 case 1.2f: // Give Buff Menu
                     {
+                        int scrollMul = 40;
+
                         if (!Main.scrolled)
                         {
-                            DrawMenu.buffMenuScrollPosition.y = 40 * intraMenuIndex;
+                            DrawMenu.buffMenuScrollPosition.y = scrollMul * intraMenuIndex;
                         }
 
                         if (intraMenuIndex > Enum.GetNames(typeof(BuffIndex)).Length - 1)
@@ -1489,20 +1496,22 @@ namespace UmbraRoR
                             intraMenuIndex = Enum.GetNames(typeof(BuffIndex)).Length - 1;
                         }
 
-                        if (DrawMenu.buffMenuScrollPosition.y > (Enum.GetNames(typeof(BuffIndex)).Length - 1) * 40)
+                        if (!Main.scrolled)
                         {
-                            DrawMenu.buffMenuScrollPosition = Vector2.zero;
-                        }
-                        if (DrawMenu.buffMenuScrollPosition.y < 0)
-                        {
-                            DrawMenu.buffMenuScrollPosition.y = (Enum.GetNames(typeof(BuffIndex)).Length - 1) * 40;
+                            if (DrawMenu.buffMenuScrollPosition.y > (Enum.GetNames(typeof(BuffIndex)).Length - 1) * scrollMul)
+                            {
+                                DrawMenu.buffMenuScrollPosition = Vector2.zero;
+                            }
+                            if (DrawMenu.buffMenuScrollPosition.y < 0)
+                            {
+                                DrawMenu.buffMenuScrollPosition.y = (Enum.GetNames(typeof(BuffIndex)).Length - 1) * scrollMul;
+                            }
                         }
                         break;
                     }
 
                 case 1.3f: // Stats Modification Menu 0-5
                     {
-
                         if (intraMenuIndex > 5)
                         {
                             intraMenuIndex = 0;
@@ -1542,9 +1551,11 @@ namespace UmbraRoR
 
                 case 3.1f: // Give Item Menu
                     {
+                        int scrollMul = 40;
+
                         if (!Main.scrolled)
                         {
-                            DrawMenu.itemSpawnerScrollPosition.y = 40 * intraMenuIndex;
+                            DrawMenu.itemSpawnerScrollPosition.y = scrollMul * intraMenuIndex;
                         }
 
                         if (intraMenuIndex > Main.items.Count - 1)
@@ -1556,22 +1567,27 @@ namespace UmbraRoR
                             intraMenuIndex = Main.items.Count - 1;
                         }
 
-                        if (DrawMenu.itemSpawnerScrollPosition.y > (Main.items.Count - 1) * 40)
+                        if (!Main.scrolled)
                         {
-                            DrawMenu.itemSpawnerScrollPosition = Vector2.zero;
-                        }
-                        if (DrawMenu.itemSpawnerScrollPosition.y < 0)
-                        {
-                            DrawMenu.itemSpawnerScrollPosition.y = (Main.items.Count - 1) * 40;
+                            if (DrawMenu.itemSpawnerScrollPosition.y > (Main.items.Count - 1) * scrollMul)
+                            {
+                                DrawMenu.itemSpawnerScrollPosition = Vector2.zero;
+                            }
+                            if (DrawMenu.itemSpawnerScrollPosition.y < 0)
+                            {
+                                DrawMenu.itemSpawnerScrollPosition.y = (Main.items.Count - 1) * scrollMul;
+                            }
                         }
                         break;
                     }
 
                 case 3.2f: // Give Equip Menu
                     {
+                        int scrollMul = 40;
+
                         if (!Main.scrolled)
                         {
-                            DrawMenu.equipmentSpawnerScrollPosition.y = 40 * intraMenuIndex;
+                            DrawMenu.equipmentSpawnerScrollPosition.y = scrollMul * intraMenuIndex;
                         }
 
                         if (intraMenuIndex > Main.equipment.Count - 1)
@@ -1583,26 +1599,31 @@ namespace UmbraRoR
                             intraMenuIndex = Main.equipment.Count - 1;
                         }
 
-                        if (DrawMenu.equipmentSpawnerScrollPosition.y > (Main.equipment.Count - 1) * 40)
+                        if (!Main.scrolled)
                         {
-                            DrawMenu.equipmentSpawnerScrollPosition = Vector2.zero;
-                        }
-                        if (DrawMenu.equipmentSpawnerScrollPosition.y < 0)
-                        {
-                            DrawMenu.equipmentSpawnerScrollPosition.y = (Main.equipment.Count - 1) * 40;
+                            if (DrawMenu.equipmentSpawnerScrollPosition.y > (Main.equipment.Count - 1) * scrollMul)
+                            {
+                                DrawMenu.equipmentSpawnerScrollPosition = Vector2.zero;
+                            }
+                            if (DrawMenu.equipmentSpawnerScrollPosition.y < 0)
+                            {
+                                DrawMenu.equipmentSpawnerScrollPosition.y = (Main.equipment.Count - 1) * scrollMul;
+                            }
                         }
                         break;
                     }
 
                 case 3.3f: // Change Chest Item/Equipment List
                     {
+                        int scrollMul = 40;
+
                         if (Main._isChestItemListOpen)
                         {
                             if (Chests.IsClosestChestEquip())
                             {
                                 if (!Main.scrolled)
                                 {
-                                    DrawMenu.chestItemChangerScrollPosition.y = 40 * intraMenuIndex;
+                                    DrawMenu.chestItemChangerScrollPosition.y = scrollMul * intraMenuIndex;
                                 }
 
                                 if (intraMenuIndex > Main.equipment.Count - 2)
@@ -1614,13 +1635,16 @@ namespace UmbraRoR
                                     intraMenuIndex = Main.equipment.Count - 2;
                                 }
 
-                                if (DrawMenu.chestItemChangerScrollPosition.y > (Main.equipment.Count - 2) * 40)
+                                if (!Main.scrolled)
                                 {
-                                    DrawMenu.chestItemChangerScrollPosition = Vector2.zero;
-                                }
-                                if (DrawMenu.chestItemChangerScrollPosition.y < 0)
-                                {
-                                    DrawMenu.chestItemChangerScrollPosition.y = (Main.equipment.Count - 2) * 40;
+                                    if (DrawMenu.chestItemChangerScrollPosition.y > (Main.equipment.Count - 2) * scrollMul)
+                                    {
+                                        DrawMenu.chestItemChangerScrollPosition = Vector2.zero;
+                                    }
+                                    if (DrawMenu.chestItemChangerScrollPosition.y < 0)
+                                    {
+                                        DrawMenu.chestItemChangerScrollPosition.y = (Main.equipment.Count - 2) * scrollMul;
+                                    }
                                 }
                             }
                             else
@@ -1639,13 +1663,16 @@ namespace UmbraRoR
                                     intraMenuIndex = Main.items.Count - 1;
                                 }
 
-                                if (DrawMenu.chestItemChangerScrollPosition.y > (Main.items.Count - 1) * 40)
+                                if (!Main.scrolled)
                                 {
-                                    DrawMenu.chestItemChangerScrollPosition = Vector2.zero;
-                                }
-                                if (DrawMenu.chestItemChangerScrollPosition.y < 0)
-                                {
-                                    DrawMenu.chestItemChangerScrollPosition.y = (Main.items.Count - 1) * 40;
+                                    if (DrawMenu.chestItemChangerScrollPosition.y > (Main.items.Count - 1) * scrollMul)
+                                    {
+                                        DrawMenu.chestItemChangerScrollPosition = Vector2.zero;
+                                    }
+                                    if (DrawMenu.chestItemChangerScrollPosition.y < 0)
+                                    {
+                                        DrawMenu.chestItemChangerScrollPosition.y = (Main.items.Count - 1) * scrollMul;
+                                    }
                                 }
                             }
                         }
@@ -1667,7 +1694,12 @@ namespace UmbraRoR
 
                 case 4.1f: // Spawn List Menu
                     {
-                        DrawMenu.spawnScrollPosition.y = 40 * intraMenuIndex;
+                        int scrollMul = 40;
+
+                        if (!Main.scrolled)
+                        {
+                            DrawMenu.spawnScrollPosition.y = scrollMul * intraMenuIndex;
+                        }
 
                         if (intraMenuIndex > Main.spawnCards.Count - 1)
                         {
@@ -1678,13 +1710,16 @@ namespace UmbraRoR
                             intraMenuIndex = Main.spawnCards.Count - 1;
                         }
 
-                        if (DrawMenu.spawnScrollPosition.y > (Main.spawnCards.Count - 1) * 40)
+                        if (!Main.scrolled)
                         {
-                            DrawMenu.spawnScrollPosition = Vector2.zero;
-                        }
-                        if (DrawMenu.spawnScrollPosition.y < 0)
-                        {
-                            DrawMenu.spawnScrollPosition.y = (Main.spawnCards.Count - 1) * 40;
+                            if (DrawMenu.spawnScrollPosition.y > (Main.spawnCards.Count - 1) * scrollMul)
+                            {
+                                DrawMenu.spawnScrollPosition = Vector2.zero;
+                            }
+                            if (DrawMenu.spawnScrollPosition.y < 0)
+                            {
+                                DrawMenu.spawnScrollPosition.y = (Main.spawnCards.Count - 1) * scrollMul;
+                            }
                         }
                         break;
                     }

--- a/Navigation.cs
+++ b/Navigation.cs
@@ -1405,6 +1405,36 @@ namespace UmbraRoR
                         break;
                     }
 
+                case 3.3f: // Change Chest Item/Equipment List
+                    {
+                        if (Main._isChestItemListOpen)
+                        {
+                            if (Chests.IsClosestChestEquip())
+                            {
+                                DrawMenu.chestItemChangerScrollPosition.y = 40 * intraMenuIndex;
+
+                                if (intraMenuIndex > Main.equipment.Count - 2)
+                                {
+                                    intraMenuIndex = 0;
+                                }
+                                if (intraMenuIndex < 0)
+                                {
+                                    intraMenuIndex = Main.equipment.Count - 2;
+                                }
+
+                                if (DrawMenu.chestItemChangerScrollPosition.y > (Main.equipment.Count - 2) * 40)
+                                {
+                                    DrawMenu.chestItemChangerScrollPosition = Vector2.zero;
+                                }
+                                if (DrawMenu.chestItemChangerScrollPosition.y < 0)
+                                {
+                                    DrawMenu.chestItemChangerScrollPosition.y = (Main.equipment.Count - 2) * 40;
+                                }
+                            }
+                        }
+                        break;
+                    }
+
                 case 4: // Spawn Menu 0 - 5
                     {
                         if (intraMenuIndex > 5)

--- a/Player.cs
+++ b/Player.cs
@@ -16,6 +16,7 @@ namespace UmbraRoR
         public static ulong xpToGive = 50;
         public static uint moneyToGive = 50;
         public static uint coinsToGive = 50;
+        public static int multiplyer = 10;
 
         public static void GiveBuff(GUIStyle buttonStyle,string buttonId)
         {

--- a/Player.cs
+++ b/Player.cs
@@ -5,7 +5,7 @@ using RoR2;
 
 namespace UmbraRoR
 {
-    public class PlayerMod
+    public class PlayerMod : MonoBehaviour
     {
         public static int damagePerLvl = 10;
         public static int CritPerLvl = 1;

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0")]
-[assembly: AssemblyFileVersion("1.3.0")]
+[assembly: AssemblyVersion("1.3.1")]
+[assembly: AssemblyFileVersion("1.3.1")]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Doesn't require BepInEx or R2API!
 This is an unofficial fork of the Spektre Menu by [BennettStaley](https://github.com/BennettStaley/)
 and was merged with [Lodington's](https://github.com/Lodington/) unofficial fork.
 
-This menu is for testing/personal fun. I do not condone the use of this menu in competitive modes such as the Prismatic Trials nor do I condone the use of this menu if it harms the experience of other players in any way. Thank you
+This menu is for testing/personal fun. I do not condone the use of this menu in competitive modes such as the Prismatic Trials nor do I condone the use of this menu if it harms the experience of other players in any way. Thank you.
 
 
 # Just released Umbra-Injector to auto inject/update Umbra Menu. Check it out [here](https://github.com/Acher0ns/Umbra-Menu-Injector)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Doesn't require BepInEx or R2API!
 This is an unofficial fork of the Spektre Menu by [BennettStaley](https://github.com/BennettStaley/)
 and was merged with [Lodington's](https://github.com/Lodington/) unofficial fork.
 
+This menu is for testing/personal fun. I do not condone the use of this menu in competitive modes such as the Prismatic Trials nor do I condone the use of this menu if it harms the experience of other players in any way. Thank you
+
 
 # Just released Umbra-Injector to auto inject/update Umbra Menu. Check it out [here](https://github.com/Acher0ns/Umbra-Menu-Injector)
 # Features

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Use mouse to select cheats. This can be done while holding tab ingame or while i
 
 Note: Some features may not work if you are not the host of the lobby
 
+- Z -> Toggle Player Menu
+- I -> Toggle Item Spawn Menu
+- C -> Toggle Flight
+- B -> Toggle Teleporter Menu
+
 
 # List of Improvements I Might Add:
 - [ ] Add filters to ESPs?
@@ -155,6 +160,25 @@ pause
 
 
 # Changelog:
+### X/XX/XXXX v1.3.1:
+- [ ] Added Menu to change whats inside chests/equipment barrels.
+- [ ] Added Scrappers and Barrels to Interactables ESP.
+- [ ] Added what item is in chests to Interactable ESP.
+- [ ] Added Keybinds:
+ - Z -> Toggle Player Menu
+ - I -> Toggle Item Spawn Menu
+ - C -> Toggle Flight
+ - B -> Toggle Teleporter Menu
+- [ ] Added better support for low resolution monitors (less than 1080p).
+- [ ] Item/Equipment list now shows friendly item names and their color based on rarity.
+- [ ] Slightly improved Navigation logic.
+- [ ] Greatly Improved Interactable ESP performance.
+- [ ] Slightly Improved the Menus Load() method.
+- [ ] Improved how teleporters are spawned
+- [ ] Fixed a bug allowing menu index to be set while Navigation was off
+- [ ] Fixed a bug not allowing you to scroll on list menus while Navigation was on
+
+
 ### 8/11/2020 v1.3.0:
 - [ ] Updated for Risk of Rain 2 1.0 Update.
 - [ ] Slightly improved ESP performances.

--- a/README.md
+++ b/README.md
@@ -172,13 +172,14 @@ pause
  - C -> Toggle Flight
  - B -> Toggle Teleporter Menu
 - [ ] Added better support for low resolution monitors (less than 1080p).
+- [ ] Added a customizable multiplier for Stats Mod Menu.
 - [ ] Item/Equipment list now shows friendly item names and their color based on rarity.
 - [ ] Slightly improved Navigation logic.
 - [ ] Greatly Improved Interactable ESP performance.
 - [ ] Slightly Improved the Menus Load() method.
-- [ ] Improved how teleporters are spawned
-- [ ] Fixed a bug allowing menu index to be set while Navigation was off
-- [ ] Fixed a bug not allowing you to scroll on list menus while Navigation was on
+- [ ] Improved how teleporters are spawned.
+- [ ] Fixed a bug allowing menu index to be set while Navigation was off.
+- [ ] Fixed a bug not allowing you to scroll on list menus while Navigation was on.
 
 
 ### 8/11/2020 v1.3.0:

--- a/Reflections.cs
+++ b/Reflections.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace UmbraRoR
+{
+    // shalzuth//RiskOfShame/Reflection.cs
+    public static class Reflections
+    {
+        public static BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic |
+                                           BindingFlags.Static | BindingFlags.FlattenHierarchy;
+        public static ConcurrentDictionary<String, FieldInfo> fields = new ConcurrentDictionary<String, FieldInfo>();
+        public static FieldInfo GetFieldFast(this Type type, String fieldName, String fieldType, String baseType)
+        {
+            var key = type.FullName + "." + fieldName + "(" + fieldType + ")" + " " + baseType;
+            if (fields.ContainsKey(key)) return fields[key];
+            var field = type.GetField(fieldName, flags);
+            if (!field.FieldType.Name.Contains(fieldType) || !field.DeclaringType.Name.Contains(baseType))
+                field = type.GetFields(flags).FirstOrDefault(f => f.Name == fieldName
+                                            && f.FieldType.ToString().Contains(fieldType)
+                                            && f.DeclaringType.ToString().Contains(baseType));
+            if (field != null) fields[key] = field;
+            return field;
+        }
+        public static ConcurrentDictionary<String, PropertyInfo> properties = new ConcurrentDictionary<String, PropertyInfo>();
+        public static PropertyInfo GetPropertyFast(this Type type, String propertyName, String propretyType, String baseType)
+        {
+            var key = type.FullName + "." + propertyName + "(" + propretyType + ")" + " " + baseType;
+            if (properties.ContainsKey(key)) return properties[key];
+            var property = type.GetProperty(propertyName, flags);
+            if (!property.PropertyType.Name.Contains(propretyType) || !property.DeclaringType.Name.Contains(baseType))
+                property = type.GetProperties(flags).FirstOrDefault(p => p.Name == propertyName
+                                            && p.PropertyType.ToString().Contains(propretyType)
+                                            && p.DeclaringType.ToString().Contains(baseType));
+            if (property != null) properties[key] = property;
+            return property;
+        }
+        public static Object GetField(this Object obj, String fieldName, String fieldType, String baseType)
+        {
+            if (obj == null) return null;
+            var objType = obj is Type ? (Type)obj : obj.GetType();
+            var field = objType.GetFieldFast(fieldName, fieldType, baseType);
+            if (field != null) return obj is Type ? field.GetValue(null) : field.GetValue(obj);
+            var property = objType.GetPropertyFast(fieldName, fieldType, baseType);
+            if (property != null) return obj is Type ? property.GetValue(null) : property.GetValue(obj);
+            return null;
+        }
+        public static T GetField<T>(this Object obj, String fieldName, String fieldType = "", String baseType = "")
+        {
+            if (String.IsNullOrEmpty(fieldType)) fieldType = typeof(T).Name;
+            if (String.IsNullOrEmpty(baseType)) baseType = obj is Type ? ((Type)obj).Name : obj.GetType().Name;
+            return (T)GetField(obj, fieldName, fieldType, baseType);
+        }
+        public static void SetField<T>(this Object obj, String fieldName, String fieldType, String baseType, T val)
+        {
+            if (obj == null) return;
+            var objType = obj.GetType();
+            var field = objType.GetFieldFast(fieldName, fieldType, baseType);
+            if (field != null)
+            {
+                field.SetValue(obj, val);
+                return;
+            }
+            var property = objType.GetPropertyFast(fieldName, fieldType, baseType);
+            if (property != null) property.SetValue(obj, val);
+        }
+        public static void SetField<T>(this Object obj, String fieldName, T val, String fieldType = "", String baseType = "")
+        {
+            if (String.IsNullOrEmpty(fieldType))
+                fieldType = typeof(T).Name;
+            if (String.IsNullOrEmpty(baseType))
+                baseType = obj is Type ? ((Type)obj).Name : obj.GetType().Name;
+            SetField(obj, fieldName, fieldType, baseType, val);
+        }
+        public static List<Object> GetList(this Object obj)
+        {
+            var methods = obj.GetType().GetMethods(flags);
+            var obj_get_Item = methods.First(m => m.Name == "get_Item");
+            var obj_Count = obj.GetType().GetProperty("Count");
+            var count = (Int32)obj_Count.GetValue(obj, new Object[0]);
+            var elements = new List<Object>();
+            for (Int32 i = 0; i < count; i++)
+                elements.Add(obj_get_Item.Invoke(obj, new Object[] { i }));
+            return elements;
+        }
+        public static Object Invoke(this Object obj, String methodName, params Object[] paramArray)
+        {
+            var type = obj is Type ? (Type)obj : obj.GetType();
+            var method = type.GetMethod(methodName, flags);
+            return obj is Type ? method.Invoke(null, paramArray) : method.Invoke(obj, paramArray);
+        }
+        public static T CreateInstance<T>(params Object[] paramArray)
+        {
+            return (T)Activator.CreateInstance(typeof(T), args: paramArray);
+        }
+    }
+}

--- a/Render.cs
+++ b/Render.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using RoR2;
 using System.Collections.Generic;
 using System.Linq;
+using EntityStates.Scrapper;
 
 namespace UmbraRoR
 {
@@ -12,6 +13,7 @@ namespace UmbraRoR
         public static List<PurchaseInteraction> purchaseInteractions = new List<PurchaseInteraction>();
         public static List<BarrelInteraction> barrelInteractions = new List<BarrelInteraction>();
         public static List<PressurePlateController> secretButtons = new List<PressurePlateController>();
+        public static List<ScrapperController> scrappers = new List<ScrapperController>();
         public static void EnableInteractables()
         {
             if (Main.onRenderIntEnable)
@@ -44,6 +46,7 @@ namespace UmbraRoR
             barrelInteractions = FindObjectsOfType<BarrelInteraction>().ToList();
             purchaseInteractions = FindObjectsOfType<PurchaseInteraction>().ToList();
             secretButtons = FindObjectsOfType<PressurePlateController>().ToList();
+            scrappers = FindObjectsOfType<ScrapperController>().ToList();
         }
 
         public static void Interactables()
@@ -75,7 +78,7 @@ namespace UmbraRoR
                 }
             }
 
-            foreach (BarrelInteraction barrel in barrelInteractions)//Main.barrelInteractions)
+            foreach (BarrelInteraction barrel in barrelInteractions)
             {
                 if (!barrel.Networkopened)
                 {
@@ -91,9 +94,9 @@ namespace UmbraRoR
                 }
             }
 
-            if (Main.secretButtons != null)
+            if (secretButtons != null)
             {
-                foreach (PressurePlateController secretButton in secretButtons)//Main.secretButtons)
+                foreach (PressurePlateController secretButton in secretButtons)
                 {
                     if (secretButton)
                     {
@@ -110,7 +113,23 @@ namespace UmbraRoR
                 }
             }
 
-            foreach (PurchaseInteraction purchaseInteraction in purchaseInteractions)//Main.purchaseInteractables)
+            foreach (ScrapperController scrapper in scrappers)
+            {
+                if (scrapper)
+                {
+                    string friendlyName = "Scrapper";
+                    Vector3 Position = Camera.main.WorldToScreenPoint(scrapper.transform.position);
+                    var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
+                    if (BoundingVector.z > 0.01)
+                    {
+                        float distance = (int)Vector3.Distance(Camera.main.transform.position, scrapper.transform.position);
+                        string boxText = $"{friendlyName}\n{distance}m";
+                        GUI.Label(new Rect(BoundingVector.x - 50f, (float)Screen.height - BoundingVector.y, 100f, 50f), boxText, Main.renderInteractablesStyle);
+                    }
+                }
+            }
+
+            foreach (PurchaseInteraction purchaseInteraction in purchaseInteractions)
             {
                 if (purchaseInteraction.available)
                 {

--- a/Render.cs
+++ b/Render.cs
@@ -5,30 +5,30 @@ using System.Collections.Generic;
 
 namespace UmbraRoR
 {
+    // Needs improvement. Causes a lot of lag
     public class Render : MonoBehaviour
     {
         public static void Interactables()
         {
-            foreach (PurchaseInteraction purchaseInteraction in Main.purchaseInteractables)
+            foreach (BarrelInteraction barrel in Main.barrelInteractions)
             {
-                if (purchaseInteraction.available)
+                if (!barrel.Networkopened)
                 {
-                    float distanceToObject = Vector3.Distance(Camera.main.transform.position, purchaseInteraction.transform.position);
-                    Vector3 Position = Camera.main.WorldToScreenPoint(purchaseInteraction.transform.position);
+                    string friendlyName = "Barrel";
+                    Vector3 Position = Camera.main.WorldToScreenPoint(barrel.transform.position);
                     var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
                     if (BoundingVector.z > 0.01)
                     {
-                        int distance = (int)distanceToObject;
-                        String friendlyName = purchaseInteraction.GetDisplayName();
-                        int cost = purchaseInteraction.cost;
-                        string boxText = $"{friendlyName}\n${cost}\n{distance}m";
+                        float distance = (int)Vector3.Distance(Camera.main.transform.position, barrel.transform.position);
+                        string boxText = $"{friendlyName}\n{distance}m";
                         GUI.Label(new Rect(BoundingVector.x - 50f, (float)Screen.height - BoundingVector.y, 100f, 50f), boxText, Main.renderInteractablesStyle);
                     }
                 }
             }
 
-            foreach (TeleporterInteraction teleporterInteraction in Main.teleporterInteractables)
+            if (TeleporterInteraction.instance)
             {
+                var teleporterInteraction = TeleporterInteraction.instance;
                 float distanceToObject = Vector3.Distance(Camera.main.transform.position, teleporterInteraction.transform.position);
                 Vector3 Position = Camera.main.WorldToScreenPoint(teleporterInteraction.transform.position);
                 var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
@@ -52,9 +52,51 @@ namespace UmbraRoR
                     GUI.Label(new Rect(BoundingVector.x - 50f, (float)Screen.height - BoundingVector.y, 100f, 50f), boxText, Main.renderTeleporterStyle);
                 }
             }
+
+            if (Main.secretButtons != null)
+            {
+                foreach (PressurePlateController secretButton in Main.secretButtons)
+                {
+                    if (secretButton)
+                    {
+                        string friendlyName = "Secret Button";
+                        Vector3 Position = Camera.main.WorldToScreenPoint(secretButton.transform.position);
+                        var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
+                        if (BoundingVector.z > 0.01)
+                        {
+                            float distance = (int)Vector3.Distance(Camera.main.transform.position, secretButton.transform.position);
+                            string boxText = $"{friendlyName}\n{distance}m";
+                            GUI.Label(new Rect(BoundingVector.x - 50f, (float)Screen.height - BoundingVector.y, 100f, 50f), boxText, Main.renderInteractablesStyle);
+                        }
+                    }
+                }
+            }
+
+            foreach (PurchaseInteraction purchaseInteraction in Main.purchaseInteractables)
+            {
+                if (purchaseInteraction.available)
+                {
+                    string dropName = null;
+                    var chest = purchaseInteraction?.gameObject.GetComponent<ChestBehavior>();
+                    if (chest)
+                    {
+                        dropName = Util.GenerateColoredString(Language.GetString(chest.GetField<PickupIndex>("dropPickup").GetPickupNameToken()), chest.GetField<PickupIndex>("dropPickup").GetPickupColor());
+                    }
+                    float distanceToObject = Vector3.Distance(Camera.main.transform.position, purchaseInteraction.transform.position);
+                    Vector3 Position = Camera.main.WorldToScreenPoint(purchaseInteraction.transform.position);
+                    var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
+                    if (BoundingVector.z > 0.01)
+                    {
+                        int distance = (int)distanceToObject;
+                        String friendlyName = purchaseInteraction.GetDisplayName();
+                        int cost = purchaseInteraction.cost;
+                        string boxText = dropName != null ? $"{friendlyName}\n${cost}\n{distance}m\n{dropName}" : $"{friendlyName}\n${cost}\n{distance}m";
+                        GUI.Label(new Rect(BoundingVector.x - 50f, (float)Screen.height - BoundingVector.y, 100f, 50f), boxText, Main.renderInteractablesStyle);
+                    }
+                }
+            }
         }
 
-        // Needs improvement. Causes a lot of lag
         public static void Mobs()
         {
             foreach (var hurtbox in Main.hurtBoxes)

--- a/Render.cs
+++ b/Render.cs
@@ -2,30 +2,52 @@ using System;
 using UnityEngine;
 using RoR2;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace UmbraRoR
 {
     // Needs improvement. Causes a lot of lag
     public class Render : MonoBehaviour
     {
+        public static List<PurchaseInteraction> purchaseInteractions = new List<PurchaseInteraction>();
+        public static List<BarrelInteraction> barrelInteractions = new List<BarrelInteraction>();
+        public static List<PressurePlateController> secretButtons = new List<PressurePlateController>();
+        public static void EnableInteractables()
+        {
+            if (Main.onRenderIntEnable)
+            {
+                DumpInteractables(null);
+                SceneDirector.onPostPopulateSceneServer += DumpInteractables;
+                Main.onRenderIntEnable = false;
+            }
+            else
+            {
+                return;
+            }
+        }
+        public static void DisableInteractables()
+        {
+            if (!Main.onRenderIntEnable)
+            {
+                SceneDirector.onPostPopulateSceneServer -= DumpInteractables;
+                Main.onRenderIntEnable = true;
+            }
+            else
+            {
+                return;
+            }
+        }
+
+        private static void DumpInteractables(SceneDirector obj)
+        {
+            Debug.Log("Dumping Interactables");
+            barrelInteractions = FindObjectsOfType<BarrelInteraction>().ToList();
+            purchaseInteractions = FindObjectsOfType<PurchaseInteraction>().ToList();
+            secretButtons = FindObjectsOfType<PressurePlateController>().ToList();
+        }
+
         public static void Interactables()
         {
-            foreach (BarrelInteraction barrel in Main.barrelInteractions)
-            {
-                if (!barrel.Networkopened)
-                {
-                    string friendlyName = "Barrel";
-                    Vector3 Position = Camera.main.WorldToScreenPoint(barrel.transform.position);
-                    var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
-                    if (BoundingVector.z > 0.01)
-                    {
-                        float distance = (int)Vector3.Distance(Camera.main.transform.position, barrel.transform.position);
-                        string boxText = $"{friendlyName}\n{distance}m";
-                        GUI.Label(new Rect(BoundingVector.x - 50f, (float)Screen.height - BoundingVector.y, 100f, 50f), boxText, Main.renderInteractablesStyle);
-                    }
-                }
-            }
-
             if (TeleporterInteraction.instance)
             {
                 var teleporterInteraction = TeleporterInteraction.instance;
@@ -53,9 +75,25 @@ namespace UmbraRoR
                 }
             }
 
+            foreach (BarrelInteraction barrel in barrelInteractions)//Main.barrelInteractions)
+            {
+                if (!barrel.Networkopened)
+                {
+                    string friendlyName = "Barrel";
+                    Vector3 Position = Camera.main.WorldToScreenPoint(barrel.transform.position);
+                    var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
+                    if (BoundingVector.z > 0.01)
+                    {
+                        float distance = (int)Vector3.Distance(Camera.main.transform.position, barrel.transform.position);
+                        string boxText = $"{friendlyName}\n{distance}m";
+                        GUI.Label(new Rect(BoundingVector.x - 50f, (float)Screen.height - BoundingVector.y, 100f, 50f), boxText, Main.renderInteractablesStyle);
+                    }
+                }
+            }
+
             if (Main.secretButtons != null)
             {
-                foreach (PressurePlateController secretButton in Main.secretButtons)
+                foreach (PressurePlateController secretButton in secretButtons)//Main.secretButtons)
                 {
                     if (secretButton)
                     {
@@ -72,7 +110,7 @@ namespace UmbraRoR
                 }
             }
 
-            foreach (PurchaseInteraction purchaseInteraction in Main.purchaseInteractables)
+            foreach (PurchaseInteraction purchaseInteraction in purchaseInteractions)//Main.purchaseInteractables)
             {
                 if (purchaseInteraction.available)
                 {

--- a/Render.cs
+++ b/Render.cs
@@ -94,21 +94,18 @@ namespace UmbraRoR
                 }
             }
 
-            if (secretButtons != null)
+            foreach (PressurePlateController secretButton in secretButtons)
             {
-                foreach (PressurePlateController secretButton in secretButtons)
+                if (secretButton)
                 {
-                    if (secretButton)
+                    string friendlyName = "Secret Button";
+                    Vector3 Position = Camera.main.WorldToScreenPoint(secretButton.transform.position);
+                    var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
+                    if (BoundingVector.z > 0.01)
                     {
-                        string friendlyName = "Secret Button";
-                        Vector3 Position = Camera.main.WorldToScreenPoint(secretButton.transform.position);
-                        var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
-                        if (BoundingVector.z > 0.01)
-                        {
-                            float distance = (int)Vector3.Distance(Camera.main.transform.position, secretButton.transform.position);
-                            string boxText = $"{friendlyName}\n{distance}m";
-                            GUI.Label(new Rect(BoundingVector.x - 50f, (float)Screen.height - BoundingVector.y, 100f, 50f), boxText, Main.renderInteractablesStyle);
-                        }
+                        float distance = (int)Vector3.Distance(Camera.main.transform.position, secretButton.transform.position);
+                        string boxText = $"{friendlyName}\n{distance}m";
+                        GUI.Label(new Rect(BoundingVector.x - 50f, (float)Screen.height - BoundingVector.y, 100f, 50f), boxText, Main.renderInteractablesStyle);
                     }
                 }
             }

--- a/Spawn.cs
+++ b/Spawn.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace UmbraRoR
 {
-    class Spawn
+    class Spawn : MonoBehaviour
     {
         public static TeamIndex[] team = { TeamIndex.Monster, TeamIndex.Neutral, TeamIndex.Player, TeamIndex.None };
         public static int teamIndex = 0;

--- a/Teleporter.cs
+++ b/Teleporter.cs
@@ -30,21 +30,28 @@ namespace UmbraRoR
                 if (portal.Equals("gold"))
                 {
                     Debug.Log("UmbraRoR : Spawned Gold Portal");
+                    TeleporterInteraction.instance.Network_shouldAttemptToSpawnGoldshoresPortal = true;
                     TeleporterInteraction.instance.shouldAttemptToSpawnGoldshoresPortal = true;
                 }
                 else if (portal.Equals("newt"))
                 {
                     Debug.Log("UmbraRoR : Spawned Shop Portal");
+                    TeleporterInteraction.instance.Network_shouldAttemptToSpawnShopPortal = true;
                     TeleporterInteraction.instance.shouldAttemptToSpawnShopPortal = true;
                 }
                 else if (portal.Equals("blue"))
                 {
                     Debug.Log("UmbraRoR : Spawned Celestal Portal");
+                    TeleporterInteraction.instance.Network_shouldAttemptToSpawnMSPortal = true;
                     TeleporterInteraction.instance.shouldAttemptToSpawnMSPortal = true;
                 }
                 else if (portal.Equals("all"))
                 {
                     Debug.Log("UmbraRoR : Spawned All Portals");
+                    TeleporterInteraction.instance.Network_shouldAttemptToSpawnGoldshoresPortal = true;
+                    TeleporterInteraction.instance.Network_shouldAttemptToSpawnShopPortal = true;
+                    TeleporterInteraction.instance.Network_shouldAttemptToSpawnMSPortal = true;
+
                     TeleporterInteraction.instance.shouldAttemptToSpawnGoldshoresPortal = true;
                     TeleporterInteraction.instance.shouldAttemptToSpawnShopPortal = true;
                     TeleporterInteraction.instance.shouldAttemptToSpawnMSPortal = true;

--- a/Teleporter.cs
+++ b/Teleporter.cs
@@ -3,7 +3,7 @@ using RoR2;
 
 namespace UmbraRoR
 {
-    public class Teleporter 
+    public class Teleporter : MonoBehaviour
     {
         public static void InstaTeleporter()
         {

--- a/UmbraRoR.csproj
+++ b/UmbraRoR.csproj
@@ -57,6 +57,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Chests.cs" />
     <Compile Include="Lobby.cs" />
     <Compile Include="Movement.cs" />
     <Compile Include="Reflections.cs" />

--- a/UmbraRoR.csproj
+++ b/UmbraRoR.csproj
@@ -59,6 +59,7 @@
   <ItemGroup>
     <Compile Include="Lobby.cs" />
     <Compile Include="Movement.cs" />
+    <Compile Include="Reflections.cs" />
     <Compile Include="Spawn.cs" />
     <Compile Include="Updates.cs" />
     <Compile Include="Navigation.cs" />
@@ -129,6 +130,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include=".editorconfig" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/UmbraRoR.sln
+++ b/UmbraRoR.sln
@@ -5,6 +5,11 @@ VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UmbraRoR", "UmbraRoR.csproj", "{16E3F076-0420-44EE-ADC5-ADF5F3E657F4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3B0A8109-26FD-4A93-A781-5FECE777AB42}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Utility.cs
+++ b/Utility.cs
@@ -30,6 +30,7 @@ namespace UmbraRoR
             Main._isItemManagerOpen = false;
             Main._isSpawnListMenuOpen = false;
             Main._isSpawnMenuOpen = false;
+            Main._isChestItemListOpen = false;
             Main.damageToggle = false;
             Main.noEquipmentCooldown = false;
             Main.critToggle = false;
@@ -45,6 +46,11 @@ namespace UmbraRoR
             Main.alwaysSprint = false;
             Main.aimBot = false;
             Main.unloadConfirm = false;
+            Main.scrolled = false;
+            Main.onChestsEnable = true;
+            Main.onChestsDisable = false;
+            Main.onRenderIntEnable = true;
+            Main.onRenderIntDisable = false;
             ItemManager.itemsToRoll = 5;
             ItemManager.isDropItemForAll = false;
             ItemManager.isDropItemFromInventory = false;

--- a/Utility.cs
+++ b/Utility.cs
@@ -262,6 +262,38 @@ namespace UmbraRoR
             };
         }
 
+        public static List<float> MenusOpenKeys()
+        {
+            List<float> menusOpenKeys = new List<float>();
+            Dictionary<float, bool> menus = new Dictionary<float, bool>()
+            {
+                {0, Main._isMenuOpen},
+                {1, Main._isPlayerMod},
+                {1.1f, Main._isChangeCharacterMenuOpen },
+                {1.2f, Main._isBuffMenuOpen},
+                {1.3f, Main._isEditStatsOpen},
+                {2, Main._isMovementOpen},
+                {3, Main._isItemManagerOpen},
+                {3.1f, Main._isItemSpawnMenuOpen},
+                {3.2f, Main._isEquipmentSpawnMenuOpen},
+                {3.3f, Main._isChestItemListOpen},
+                {4, Main._isSpawnMenuOpen},
+                {4.1f, Main._isSpawnListMenuOpen},
+                {5, Main._isTeleMenuOpen},
+                {6, Main._isESPMenuOpen },
+                {7, Main._isLobbyMenuOpen}, 
+            };
+
+            foreach (var menu in menus)
+            {
+                if (menu.Value)
+                {
+                    menusOpenKeys.Add(menu.Key);
+                }
+            }
+            return menusOpenKeys;
+        }
+
         #region Debugging
         public static void WriteToLog(string logContent)
         {

--- a/Utility.cs
+++ b/Utility.cs
@@ -190,15 +190,21 @@ namespace UmbraRoR
             return spawnCards;
         }
 
-        public static List<UnityEngine.Object> GetPurchaseInteractions()
+        public static List<PurchaseInteraction> GetPurchaseInteractions()
         {
-            var purchaseInteractables = FindObjectsOfType(typeof(PurchaseInteraction)).ToList();
+            var purchaseInteractables = FindObjectsOfType<PurchaseInteraction>().ToList();
             return purchaseInteractables;
         }
 
-        public static List<UnityEngine.Object> GetTeleporterInteractions()
+        public static List<BarrelInteraction> GetBarrelInterations()
         {
-            var teleporterInteractions = FindObjectsOfType(typeof(TeleporterInteraction)).ToList();
+            var barrels = FindObjectsOfType<BarrelInteraction>().ToList();
+            return barrels;
+        }
+
+        public static List<PressurePlateController> GetSecretButtons()
+        {
+            var teleporterInteractions = FindObjectsOfType<PressurePlateController>().ToList();
             return teleporterInteractions;
         }
 

--- a/Utility.cs
+++ b/Utility.cs
@@ -87,6 +87,9 @@ namespace UmbraRoR
             Main.godToggle = !Main.godToggle;
             Main.GetCharacter();
             Main.godToggle = !Main.godToggle;
+            Main.aimBot = !Main.aimBot;
+            Main.GetCharacter();
+            Main.aimBot = !Main.aimBot;
         }
         #endregion
 


### PR DESCRIPTION
- Added Menu to change whats inside chests/equipment barrels.
- Added Scrappers and Barrels to Interactables ESP.
- Added what item is in chests to Interactable ESP.
- Added Keybinds:
    - Z -> Toggle Player Menu
    - I -> Toggle Item Spawn Menu
    - C -> Toggle Flight
    - B -> Toggle Teleporter Menu
- Added better support for low resolution monitors (less than 1080p).
- Added a customizable multiplier for Stats Mod Menu.
- Item/Equipment list now shows friendly item names and their color based on rarity.
- Slightly improved Navigation logic.
- Greatly Improved Interactable ESP performance.
- Slightly Improved the Menus Load() method.
- Improved how teleporters are spawned.
- Fixed a bug allowing menu index to be set while Navigation was off.
- Fixed a bug not allowing you to scroll on list menus while Navigation was on.