### PR TITLE
Fixes for the Survivors of the Void DLC Update

### DIFF
--- a/Menus/Items.cs
+++ b/Menus/Items.cs
@@ -351,6 +351,7 @@ namespace UmbraMenu.Menus
             List<ItemIndex> tier2 = new List<ItemIndex>();
             List<ItemIndex> tier3 = new List<ItemIndex>();
             List<ItemIndex> lunar = new List<ItemIndex>();
+            List<ItemIndex> voidT = new List<ItemIndex>();
 
             foreach (ItemIndex itemIndex in ItemCatalog.tier1ItemList)
             {
@@ -369,12 +370,18 @@ namespace UmbraMenu.Menus
                 lunar.Add(itemIndex);
             }
 
+            foreach (ItemIndex itemIndex in ItemCatalog.tier3ItemList)
+            {
+                lunar.Add(itemIndex);
+            }
+
 
 
             weightedSelection.AddChoice(tier1, 70f);
             weightedSelection.AddChoice(tier2, 22.5f);
             weightedSelection.AddChoice(tier3, 5f);
             weightedSelection.AddChoice(lunar, 2.5f);
+            weightedSelection.AddChoice(voidT, 0.5f);
             return weightedSelection;
         }
 

--- a/Menus/Player.cs
+++ b/Menus/Player.cs
@@ -246,7 +246,7 @@ namespace UmbraMenu.Menus
                     {
                         // works
                         // Buff
-                        UmbraMenu.LocalPlayerBody.AddBuff(BuffCatalog.FindBuffIndex("Intangible"));
+                        //UmbraMenu.LocalPlayerBody.AddBuff(BuffDef..FindBuffIndex("Intangible"));
                         break;
                     }
 

--- a/Menus/Render.cs
+++ b/Menus/Render.cs
@@ -207,7 +207,7 @@ namespace UmbraMenu.Menus
                     var chest = purchaseInteraction?.gameObject.GetComponent<ChestBehavior>();
                     if (chest)
                     {
-                        dropName = Util.GenerateColoredString(Language.GetString(chest.GetField<PickupIndex>("dropPickup").GetPickupNameToken()), chest.GetField<PickupIndex>("dropPickup").GetPickupColor());
+                        dropName = Util.GenerateColoredString(Language.GetString(chest.dropPickup.GetPickupNameToken()), chest.dropPickup.GetPickupColor());
                     }
                     float distanceToObject = Vector3.Distance(Camera.main.transform.position, purchaseInteraction.transform.position);
                     Vector3 Position = Camera.main.WorldToScreenPoint(purchaseInteraction.transform.position);

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.1")]
-[assembly: AssemblyFileVersion("2.0.1")]
+[assembly: AssemblyVersion("2.0.3")]
+[assembly: AssemblyFileVersion("2.0.3")]

--- a/UmbraMenu.cs
+++ b/UmbraMenu.cs
@@ -12,7 +12,7 @@ namespace UmbraMenu
     {
         public const string
             NAME = "U M B R A",
-            VERSION = "2.0.1";
+            VERSION = "2.0.3";
 
         public static string SETTINGSPATH = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), $"UmbraMenu/settings-{VERSION}.ini");
 
@@ -316,7 +316,7 @@ namespace UmbraMenu
                 {
                     LocalNetworkUser = null;
 
-                    foreach (NetworkUser readOnlyInstance in NetworkUser.readOnlyInstancesList)   
+                    foreach (NetworkUser readOnlyInstance in NetworkUser.readOnlyLocalPlayersList)   
                     {
                         if (readOnlyInstance.isLocalPlayer)
                         {

--- a/UmbraMenu.csproj
+++ b/UmbraMenu.csproj
@@ -115,10 +115,15 @@
     <EmbeddedResource Include="Octokit.dll" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
+    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>G:\Programs\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="HGCSharpUtils">
+    <Reference Include="com.unity.multiplayer-hlapi.Runtime">
+      <HintPath>G:\Programs\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\com.unity.multiplayer-hlapi.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="HGCSharpUtils, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>G:\Programs\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\HGCSharpUtils.dll</HintPath>
     </Reference>
     <Reference Include="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -129,25 +134,37 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>.\Octokit.dll</HintPath>
     </Reference>
-    <Reference Include="Rewired_Core">
+    <Reference Include="Rewired_Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>G:\Programs\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\Rewired_Core.dll</HintPath>
+    </Reference>
+    <Reference Include="RoR2">
+      <HintPath>G:\Programs\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\RoR2.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <HintPath>G:\Programs\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\System.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine">
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>G:\Programs\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.CoreModule">
+    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>G:\Programs\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.IMGUIModule">
+    <Reference Include="UnityEngine.IMGUIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>G:\Programs\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.Networking">
-      <HintPath>G:\Programs\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.Networking.dll</HintPath>
+    <Reference Include="UnityEngine.InputLegacyModule">
+      <HintPath>G:\Programs\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.TextRenderingModule">
+    <Reference Include="UnityEngine.TextCoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>G:\Programs\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.TextCoreModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>G:\Programs\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
   </ItemGroup>

--- a/Utility.cs
+++ b/Utility.cs
@@ -191,7 +191,7 @@ namespace UmbraMenu
             List<ItemIndex> tier2 = new List<ItemIndex>();
             List<ItemIndex> tier1 = new List<ItemIndex>();
             List<ItemIndex> lunar = new List<ItemIndex>();
-            List<BuffIndex> boss = new List<BuffIndex>();
+            List<ItemIndex> voidt = new List<ItemIndex>();
 
             foreach (ItemIndex itemIndex in ItemCatalog.tier1ItemList)
             {
@@ -208,8 +208,16 @@ namespace UmbraMenu
             foreach (ItemIndex itemIndex in ItemCatalog.lunarItemList)
             {
                 lunar.Add(itemIndex);
-            }        
-            var result = items.Concat(tier3).Concat(tier2).Concat(tier1).Concat(lunar).ToList();
+            }
+            foreach (ItemDef def in ItemCatalog.allItemDefs)
+            {
+                if (def.tier == ItemTier.VoidTier1 || def.tier == ItemTier.VoidTier2 || def.tier == ItemTier.VoidTier3)
+                {
+                    voidt.Add(def.itemIndex);
+                }
+            }
+
+            var result = items.Concat(tier3).Concat(tier2).Concat(tier1).Concat(lunar).Concat(voidt).ToList();
 
 
             return result;                      


### PR DESCRIPTION
Mostly Simple updates to the code.

- Fixed to the extent where the game won't crash anymore after injecting.
- Added all new Void Items to the ItemList Pool
- Fixed the chest ESP not applying properly
- Temporarily Removed Intangible Godmode 